### PR TITLE
4.6 Update/add whitelisted raffle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,6 @@ dependencies = [
 [[package]]
 name = "cw-denom"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1073,7 +1072,6 @@ dependencies = [
 [[package]]
 name = "cw-hooks"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1317,7 +1315,6 @@ dependencies = [
 [[package]]
 name = "cw-paginate-storage"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
@@ -1385,7 +1382,6 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-issuer"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1404,7 +1400,6 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-types"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1636,7 +1631,6 @@ dependencies = [
 [[package]]
 name = "cw20-stake"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1660,7 +1654,6 @@ dependencies = [
 [[package]]
 name = "cw20-stake-external-rewards"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1682,7 +1675,6 @@ dependencies = [
 [[package]]
 name = "cw20-stake-reward-distributor"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1833,7 +1825,6 @@ dependencies = [
 [[package]]
 name = "cw721-controllers"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1845,7 +1836,6 @@ dependencies = [
 [[package]]
 name = "dao-cw-orch"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
  "cw-orch",
@@ -1877,7 +1867,6 @@ dependencies = [
 [[package]]
 name = "dao-cw721-extensions"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1908,7 +1897,6 @@ dependencies = [
 [[package]]
 name = "dao-dao-core"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1939,7 +1927,6 @@ dependencies = [
 [[package]]
 name = "dao-dao-macros"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "proc-macro2",
@@ -1963,7 +1950,6 @@ dependencies = [
 [[package]]
 name = "dao-hooks"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1992,7 +1978,6 @@ dependencies = [
 [[package]]
 name = "dao-interface"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2007,7 +1992,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-approval-single"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2023,7 +2007,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-approver"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2059,7 +2042,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-base"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2078,7 +2060,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-multiple"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2103,7 +2084,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-single"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2115,7 +2095,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-condorcet"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2132,7 +2111,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-hook-counter"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2146,7 +2124,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-multiple"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2195,7 +2172,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-single"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2219,7 +2195,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-sudo"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2234,7 +2209,6 @@ dependencies = [
 [[package]]
 name = "dao-test-custom-factory"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2284,7 +2258,6 @@ dependencies = [
 [[package]]
 name = "dao-voting"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2300,7 +2273,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-balance"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2339,7 +2311,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-staked"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2359,7 +2330,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw4"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2377,7 +2347,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-roles"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2399,7 +2368,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-staked"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2422,7 +2390,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-token-staked"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,6 @@ dependencies = [
 [[package]]
 name = "cw-denom"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1087,7 +1086,6 @@ dependencies = [
 [[package]]
 name = "cw-hooks"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1433,7 +1431,6 @@ dependencies = [
 [[package]]
 name = "cw-paginate-storage"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
@@ -1501,7 +1498,6 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-issuer"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1520,7 +1516,6 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-types"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1752,7 +1747,6 @@ dependencies = [
 [[package]]
 name = "cw20-stake"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1776,7 +1770,6 @@ dependencies = [
 [[package]]
 name = "cw20-stake-external-rewards"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1798,7 +1791,6 @@ dependencies = [
 [[package]]
 name = "cw20-stake-reward-distributor"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1979,7 +1971,6 @@ dependencies = [
 [[package]]
 name = "cw721-controllers"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1991,7 +1982,6 @@ dependencies = [
 [[package]]
 name = "dao-cw-orch"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
  "cw-orch 0.22.2",
@@ -2023,7 +2013,6 @@ dependencies = [
 [[package]]
 name = "dao-cw721-extensions"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2054,7 +2043,6 @@ dependencies = [
 [[package]]
 name = "dao-dao-core"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2085,7 +2073,6 @@ dependencies = [
 [[package]]
 name = "dao-dao-macros"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "proc-macro2",
@@ -2109,7 +2096,6 @@ dependencies = [
 [[package]]
 name = "dao-hooks"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2138,7 +2124,6 @@ dependencies = [
 [[package]]
 name = "dao-interface"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2153,7 +2138,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-approval-single"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2169,7 +2153,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-approver"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2205,7 +2188,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-base"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2224,7 +2206,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-multiple"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2249,7 +2230,6 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-single"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2261,7 +2241,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-condorcet"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2278,7 +2257,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-hook-counter"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2292,7 +2270,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-multiple"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2341,7 +2318,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-single"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2365,7 +2341,6 @@ dependencies = [
 [[package]]
 name = "dao-proposal-sudo"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2380,7 +2355,6 @@ dependencies = [
 [[package]]
 name = "dao-test-custom-factory"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2430,7 +2404,6 @@ dependencies = [
 [[package]]
 name = "dao-voting"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2446,7 +2419,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-balance"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2485,7 +2457,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-staked"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2505,7 +2476,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw4"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2523,7 +2493,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-roles"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2545,7 +2514,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-staked"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2568,7 +2536,6 @@ dependencies = [
 [[package]]
 name = "dao-voting-token-staked"
 version = "2.4.2"
-source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,12 +141,15 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
+ "cw-orch 0.23.0",
+ "cw-orch-clone-testing 0.5.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 2.3.0",
- "cw721 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (git+https://github.com/AbstractSDK/cw-nfts)",
  "dao-dao-core 2.3.0",
  "dao-interface 2.3.0",
  "dao-pre-propose-single 2.3.0",
@@ -147,6 +159,8 @@ dependencies = [
  "hex",
  "nft-loans-nc",
  "nois",
+ "p2p-trading",
+ "p2p-trading-export",
  "raffles",
  "rand",
  "schemars",
@@ -510,7 +524,7 @@ dependencies = [
  "cosmrs",
  "cosmwasm-std",
  "cosmwasm-vm",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "derivative",
@@ -1050,6 +1064,7 @@ dependencies = [
 [[package]]
 name = "cw-denom"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1072,6 +1087,7 @@ dependencies = [
 [[package]]
 name = "cw-hooks"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1109,8 +1125,33 @@ dependencies = [
  "cosmwasm-std",
  "cw-orch-contract-derive",
  "cw-orch-core",
- "cw-orch-daemon",
- "cw-orch-fns-derive",
+ "cw-orch-daemon 0.22.1",
+ "cw-orch-fns-derive 0.19.1",
+ "cw-orch-mock",
+ "cw-orch-networks",
+ "cw-orch-traits",
+ "cw-utils 1.0.3",
+ "hex",
+ "log",
+ "schemars",
+ "serde",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cw-orch"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c76d9dd1c2632359f964e3531e5d0833d9022ae9fb216ce9aaaf36070d8bdf"
+dependencies = [
+ "anyhow",
+ "cosmrs",
+ "cosmwasm-std",
+ "cw-orch-contract-derive",
+ "cw-orch-core",
+ "cw-orch-daemon 0.23.5",
+ "cw-orch-fns-derive 0.21.0",
  "cw-orch-mock",
  "cw-orch-networks",
  "cw-orch-traits",
@@ -1133,7 +1174,28 @@ dependencies = [
  "clone-cw-multi-test",
  "cosmwasm-std",
  "cw-orch-core",
- "cw-orch-daemon",
+ "cw-orch-daemon 0.22.1",
+ "cw-orch-mock",
+ "cw-utils 1.0.3",
+ "itertools 0.12.1",
+ "log",
+ "serde",
+ "sha2 0.10.8",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "cw-orch-clone-testing"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4abedeb2eeec24f9d4367503acebb6b304ef41b5478fb41174de6a473cfaf8ae"
+dependencies = [
+ "anyhow",
+ "clone-cw-multi-test",
+ "cosmwasm-std",
+ "cw-orch-core",
+ "cw-orch-daemon 0.23.5",
  "cw-orch-mock",
  "cw-utils 1.0.3",
  "itertools 0.12.1",
@@ -1157,14 +1219,15 @@ dependencies = [
 
 [[package]]
 name = "cw-orch-core"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8e62b4d04699596bc2f45c57a8e5459495584d8127588ae4bbe7f95d616b61"
+checksum = "b60b3a78e06f38cc7d23127489f356b357d795df8c62090bc66c759f875cbc5f"
 dependencies = [
  "abstract-cw-multi-test",
  "anyhow",
  "cosmos-sdk-proto 0.21.1",
  "cosmwasm-std",
+ "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "dirs",
  "log",
@@ -1215,10 +1278,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-orch-daemon"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5ddf3e3d51a72acdca54aaa89a3828bb26b720648b3c10bd9ec5cefc7c49c"
+dependencies = [
+ "anyhow",
+ "async-recursion",
+ "base16",
+ "base64",
+ "bitcoin",
+ "chrono",
+ "cosmrs",
+ "cosmwasm-std",
+ "cw-orch-core",
+ "cw-orch-networks",
+ "cw-orch-traits",
+ "dirs",
+ "ed25519-dalek",
+ "eyre",
+ "file-lock",
+ "flate2",
+ "hex",
+ "hkd32",
+ "lazy_static",
+ "log",
+ "once_cell",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "rand_core 0.6.4",
+ "regex",
+ "reqwest",
+ "ring",
+ "ripemd",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
 name = "cw-orch-fns-derive"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9acb7a15bfacc52abdf312a9fffb139883c1effb6ea7e645cd39580a8527463"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cw-orch-fns-derive"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd0a41e97819cee77efeeee0aa82bc0b029a9cb7a5a4b47de0c87f1bf69802"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1315,6 +1433,7 @@ dependencies = [
 [[package]]
 name = "cw-paginate-storage"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
@@ -1382,6 +1501,7 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-issuer"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1400,6 +1520,7 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-types"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1631,12 +1752,13 @@ dependencies = [
 [[package]]
 name = "cw20-stake"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
  "cw-hooks 2.4.2",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-ownable",
  "cw-paginate-storage 2.4.2",
  "cw-storage-plus 1.2.0",
@@ -1654,11 +1776,12 @@ dependencies = [
 [[package]]
 name = "cw20-stake-external-rewards"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -1675,10 +1798,11 @@ dependencies = [
 [[package]]
 name = "cw20-stake-reward-distributor"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -1787,6 +1911,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw721"
+version = "0.18.0"
+source = "git+https://github.com/AbstractSDK/cw-nfts#2cfdc7964e102bdacd55085dfdbeb185c2134e8e"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.3",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw721-base"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,8 +1951,26 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "cw721 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw721-base 0.16.0",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw721-base"
+version = "0.18.0"
+source = "git+https://github.com/AbstractSDK/cw-nfts#2cfdc7964e102bdacd55085dfdbeb185c2134e8e"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-orch 0.22.2",
+ "cw-ownable",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
+ "cw721 0.18.0 (git+https://github.com/AbstractSDK/cw-nfts)",
  "schemars",
  "serde",
  "thiserror",
@@ -1825,6 +1979,7 @@ dependencies = [
 [[package]]
 name = "cw721-controllers"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1836,13 +1991,14 @@ dependencies = [
 [[package]]
 name = "dao-cw-orch"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw20-stake 2.4.2",
  "cw20-stake-external-rewards",
  "cw20-stake-reward-distributor",
- "cw721-base 0.18.0",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dao-dao-core 2.4.2",
  "dao-interface 2.4.2",
  "dao-pre-propose-approval-single",
@@ -1867,6 +2023,7 @@ dependencies = [
 [[package]]
 name = "dao-cw721-extensions"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1888,7 +2045,7 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
- "cw721 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dao-dao-macros 2.3.0",
  "dao-interface 2.3.0",
  "thiserror",
@@ -1897,6 +2054,7 @@ dependencies = [
 [[package]]
 name = "dao-dao-core"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1906,7 +2064,7 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
- "cw721 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dao-dao-macros 2.4.2",
  "dao-interface 2.4.2",
  "thiserror",
@@ -1927,6 +2085,7 @@ dependencies = [
 [[package]]
 name = "dao-dao-macros"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "proc-macro2",
@@ -1950,6 +2109,7 @@ dependencies = [
 [[package]]
 name = "dao-hooks"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1971,27 +2131,29 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
- "cw721 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmosis-std 0.19.2",
 ]
 
 [[package]]
 name = "dao-interface"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
- "cw721 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmosis-std 0.20.1",
 ]
 
 [[package]]
 name = "dao-pre-propose-approval-single"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2007,6 +2169,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-approver"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2042,12 +2205,13 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-base"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom 2.4.2",
  "cw-hooks 2.4.2",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2060,6 +2224,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-multiple"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2084,6 +2249,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-single"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2095,10 +2261,11 @@ dependencies = [
 [[package]]
 name = "dao-proposal-condorcet"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2111,10 +2278,11 @@ dependencies = [
 [[package]]
 name = "dao-proposal-hook-counter"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
  "dao-hooks 2.4.2",
@@ -2124,11 +2292,12 @@ dependencies = [
 [[package]]
 name = "dao-proposal-multiple"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-hooks 2.4.2",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2172,11 +2341,12 @@ dependencies = [
 [[package]]
 name = "dao-proposal-single"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-hooks 2.4.2",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-proposal-single",
  "cw-storage-plus 1.2.0",
  "cw-utils 0.13.4",
@@ -2195,10 +2365,11 @@ dependencies = [
 [[package]]
 name = "dao-proposal-sudo"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
  "dao-dao-macros 2.4.2",
@@ -2209,17 +2380,18 @@ dependencies = [
 [[package]]
 name = "dao-test-custom-factory"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "cw721 0.18.0",
- "cw721-base 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dao-dao-macros 2.4.2",
  "dao-interface 2.4.2",
  "dao-voting 2.4.2",
@@ -2258,6 +2430,7 @@ dependencies = [
 [[package]]
 name = "dao-voting"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2273,10 +2446,11 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-balance"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2311,10 +2485,11 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-staked"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2330,10 +2505,11 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw4"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2347,17 +2523,18 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-roles"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw4",
- "cw721 0.18.0",
- "cw721-base 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw721-controllers",
  "dao-cw721-extensions",
  "dao-dao-macros 2.4.2",
@@ -2368,17 +2545,18 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-staked"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
  "cw-hooks 2.4.2",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "cw721 0.18.0",
- "cw721-base 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw721-controllers",
  "dao-dao-macros 2.4.2",
  "dao-hooks 2.4.2",
@@ -2390,12 +2568,13 @@ dependencies = [
 [[package]]
 name = "dao-voting-token-staked"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
  "cw-hooks 2.4.2",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
@@ -2831,6 +3010,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "file-lock"
+version = "2.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "040b48f80a749da50292d0f47a1e2d5bf1d772f52836c07f64bfccc62ba6e664"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "flate2"
@@ -3513,8 +3702,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "cw721 0.18.0",
- "cw721-base 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nois",
  "schemars",
  "serde",
@@ -3743,18 +3932,23 @@ version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-orch 0.23.0",
  "cw-storage-plus 0.13.4",
  "cw1155",
  "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base 0.13.4",
  "cw721 0.13.4",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom",
  "itertools 0.10.5",
  "p2p-trading-export",
  "schemars",
  "serde",
+ "sg721",
+ "sg721-base",
  "thiserror",
+ "utils",
 ]
 
 [[package]]
@@ -3763,6 +3957,7 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-orch 0.23.0",
  "cw-storage-plus 0.13.4",
  "cw20 0.13.4",
  "cw20-base 0.13.4",
@@ -3772,6 +3967,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "utils",
 ]
 
 [[package]]
@@ -4109,14 +4305,14 @@ version = "0.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-orch",
+ "cw-orch 0.22.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw721 0.18.0",
- "cw721-base 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dao-interface 2.3.0",
  "nois",
  "rand",
@@ -4226,6 +4422,35 @@ dependencies = [
  "slice-group-by",
  "smallvec",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "region"
@@ -4527,9 +4752,9 @@ dependencies = [
  "anyhow",
  "cosmrs",
  "cosmwasm-std",
- "cw-orch",
- "cw-orch-clone-testing",
- "cw721 0.18.0",
+ "cw-orch 0.22.2",
+ "cw-orch-clone-testing 0.4.1",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dao-cw-orch",
  "dao-pre-propose-base 2.4.2",
  "dao-pre-propose-single 2.4.2",
@@ -4766,7 +4991,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils 1.0.3",
- "cw721 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "serde",
  "thiserror",
@@ -4843,7 +5068,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-ownable",
  "cw-utils 1.0.3",
- "cw721-base 0.18.0",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "thiserror",
 ]
@@ -4860,8 +5085,8 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "cw721 0.18.0",
- "cw721-base 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sg-std",
  "sg721",
@@ -5687,8 +5912,8 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "cw721 0.18.0",
- "cw721-base 0.18.0",
+ "cw721 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.6.4",
  "rand_xoshiro",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,7 @@ dependencies = [
 [[package]]
 name = "cw-denom"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1086,6 +1087,7 @@ dependencies = [
 [[package]]
 name = "cw-hooks"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1431,6 +1433,7 @@ dependencies = [
 [[package]]
 name = "cw-paginate-storage"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
@@ -1498,6 +1501,7 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-issuer"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1516,6 +1520,7 @@ dependencies = [
 [[package]]
 name = "cw-tokenfactory-types"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1747,6 +1752,7 @@ dependencies = [
 [[package]]
 name = "cw20-stake"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1770,6 +1776,7 @@ dependencies = [
 [[package]]
 name = "cw20-stake-external-rewards"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1791,6 +1798,7 @@ dependencies = [
 [[package]]
 name = "cw20-stake-reward-distributor"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1971,6 +1979,7 @@ dependencies = [
 [[package]]
 name = "cw721-controllers"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1982,6 +1991,7 @@ dependencies = [
 [[package]]
 name = "dao-cw-orch"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-std",
  "cw-orch 0.22.2",
@@ -2013,6 +2023,7 @@ dependencies = [
 [[package]]
 name = "dao-cw721-extensions"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2043,6 +2054,7 @@ dependencies = [
 [[package]]
 name = "dao-dao-core"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2073,6 +2085,7 @@ dependencies = [
 [[package]]
 name = "dao-dao-macros"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "proc-macro2",
@@ -2096,6 +2109,7 @@ dependencies = [
 [[package]]
 name = "dao-hooks"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2124,6 +2138,7 @@ dependencies = [
 [[package]]
 name = "dao-interface"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2138,6 +2153,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-approval-single"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2153,6 +2169,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-approver"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2188,6 +2205,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-base"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2206,6 +2224,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-multiple"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2230,6 +2249,7 @@ dependencies = [
 [[package]]
 name = "dao-pre-propose-single"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2241,6 +2261,7 @@ dependencies = [
 [[package]]
 name = "dao-proposal-condorcet"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2257,6 +2278,7 @@ dependencies = [
 [[package]]
 name = "dao-proposal-hook-counter"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2270,6 +2292,7 @@ dependencies = [
 [[package]]
 name = "dao-proposal-multiple"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2318,6 +2341,7 @@ dependencies = [
 [[package]]
 name = "dao-proposal-single"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2341,6 +2365,7 @@ dependencies = [
 [[package]]
 name = "dao-proposal-sudo"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2355,6 +2380,7 @@ dependencies = [
 [[package]]
 name = "dao-test-custom-factory"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2404,6 +2430,7 @@ dependencies = [
 [[package]]
 name = "dao-voting"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2419,6 +2446,7 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-balance"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2457,6 +2485,7 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw20-staked"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2476,6 +2505,7 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw4"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2493,6 +2523,7 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-roles"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2514,6 +2545,7 @@ dependencies = [
 [[package]]
 name = "dao-voting-cw721-staked"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2536,6 +2568,7 @@ dependencies = [
 [[package]]
 name = "dao-voting-token-staked"
 version = "2.4.2"
+source = "git+https://github.com/Kayanski/dao-contracts?branch=development#8c945acdb0746ec84d15cfebeadcfe32122f85a2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/p2p-trading/Cargo.toml
+++ b/contracts/p2p-trading/Cargo.toml
@@ -38,7 +38,12 @@ thiserror = { version = "1.0.23" }
 
 # Local Modules
 p2p-trading-export = { path = "../../packages/p2p-trading", version = "0.1.0" }
+cw-orch = "0.23.0"
+utils = { version = "0.1.0", path = "../../packages/utils" }
+sg721.workspace = true
+cw721-base = "0.18.0"
+sg721-base = { workspace = true, features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-getrandom = { version="^0.2", features = ["js"] }
+getrandom = { version = "^0.2", features = ["js"] }

--- a/contracts/p2p-trading/schema/all_counter_trades_response.json
+++ b/contracts/p2p-trading/schema/all_counter_trades_response.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AllCounterTradesResponse",
+  "type": "object",
+  "required": [
+    "counter_trades"
+  ],
+  "properties": {
+    "counter_trades": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TradeResponse"
+      }
+    }
+  },
+  "definitions": {
+    "AdditionalTradeInfoResponse": {
+      "type": "object",
+      "required": [
+        "nfts_wanted",
+        "time",
+        "tokens_wanted"
+      ],
+      "properties": {
+        "nfts_wanted": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
+        },
+        "owner_comment": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Comment"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "time": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "tokens_wanted": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetInfo"
+          }
+        },
+        "trade_preview": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AssetInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trader_comment": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Comment"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "AssetInfo": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "cw721_coin"
+          ],
+          "properties": {
+            "cw721_coin": {
+              "$ref": "#/definitions/Cw721Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "coin"
+          ],
+          "properties": {
+            "coin": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "sg721_token"
+          ],
+          "properties": {
+            "sg721_token": {
+              "$ref": "#/definitions/Sg721Token"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Comment": {
+      "type": "object",
+      "required": [
+        "comment",
+        "time"
+      ],
+      "properties": {
+        "comment": {
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/Timestamp"
+        }
+      }
+    },
+    "CounterTradeInfo": {
+      "type": "object",
+      "required": [
+        "counter_id",
+        "trade_id"
+      ],
+      "properties": {
+        "counter_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "trade_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Cw721Coin": {
+      "type": "object",
+      "required": [
+        "address",
+        "token_id"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "token_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Sg721Token": {
+      "type": "object",
+      "required": [
+        "address",
+        "token_id"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "token_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "TradeInfoResponse": {
+      "type": "object",
+      "required": [
+        "additional_info",
+        "assets_withdrawn",
+        "associated_assets",
+        "owner",
+        "state",
+        "whitelisted_users"
+      ],
+      "properties": {
+        "accepted_info": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CounterTradeInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "additional_info": {
+          "$ref": "#/definitions/AdditionalTradeInfoResponse"
+        },
+        "assets_withdrawn": {
+          "type": "boolean"
+        },
+        "associated_assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetInfo"
+          }
+        },
+        "last_counter_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "owner": {
+          "$ref": "#/definitions/Addr"
+        },
+        "state": {
+          "$ref": "#/definitions/TradeState"
+        },
+        "whitelisted_users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
+        }
+      }
+    },
+    "TradeResponse": {
+      "type": "object",
+      "required": [
+        "trade_id"
+      ],
+      "properties": {
+        "counter_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "trade_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "trade_info": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TradeInfoResponse"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "TradeState": {
+      "type": "string",
+      "enum": [
+        "created",
+        "published",
+        "countered",
+        "refused",
+        "accepted",
+        "cancelled"
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/p2p-trading/schema/all_trades_response.json
+++ b/contracts/p2p-trading/schema/all_trades_response.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AllTradesResponse",
+  "type": "object",
+  "required": [
+    "trades"
+  ],
+  "properties": {
+    "trades": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TradeResponse"
+      }
+    }
+  },
+  "definitions": {
+    "AdditionalTradeInfoResponse": {
+      "type": "object",
+      "required": [
+        "nfts_wanted",
+        "time",
+        "tokens_wanted"
+      ],
+      "properties": {
+        "nfts_wanted": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
+        },
+        "owner_comment": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Comment"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "time": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "tokens_wanted": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetInfo"
+          }
+        },
+        "trade_preview": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AssetInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trader_comment": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Comment"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "AssetInfo": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "cw721_coin"
+          ],
+          "properties": {
+            "cw721_coin": {
+              "$ref": "#/definitions/Cw721Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "coin"
+          ],
+          "properties": {
+            "coin": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "sg721_token"
+          ],
+          "properties": {
+            "sg721_token": {
+              "$ref": "#/definitions/Sg721Token"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Comment": {
+      "type": "object",
+      "required": [
+        "comment",
+        "time"
+      ],
+      "properties": {
+        "comment": {
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/Timestamp"
+        }
+      }
+    },
+    "CounterTradeInfo": {
+      "type": "object",
+      "required": [
+        "counter_id",
+        "trade_id"
+      ],
+      "properties": {
+        "counter_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "trade_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Cw721Coin": {
+      "type": "object",
+      "required": [
+        "address",
+        "token_id"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "token_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Sg721Token": {
+      "type": "object",
+      "required": [
+        "address",
+        "token_id"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "token_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "TradeInfoResponse": {
+      "type": "object",
+      "required": [
+        "additional_info",
+        "assets_withdrawn",
+        "associated_assets",
+        "owner",
+        "state",
+        "whitelisted_users"
+      ],
+      "properties": {
+        "accepted_info": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CounterTradeInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "additional_info": {
+          "$ref": "#/definitions/AdditionalTradeInfoResponse"
+        },
+        "assets_withdrawn": {
+          "type": "boolean"
+        },
+        "associated_assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetInfo"
+          }
+        },
+        "last_counter_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "owner": {
+          "$ref": "#/definitions/Addr"
+        },
+        "state": {
+          "$ref": "#/definitions/TradeState"
+        },
+        "whitelisted_users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
+        }
+      }
+    },
+    "TradeResponse": {
+      "type": "object",
+      "required": [
+        "trade_id"
+      ],
+      "properties": {
+        "counter_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "trade_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "trade_info": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TradeInfoResponse"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "TradeState": {
+      "type": "string",
+      "enum": [
+        "created",
+        "published",
+        "countered",
+        "refused",
+        "accepted",
+        "cancelled"
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/p2p-trading/schema/execute_msg.json
+++ b/contracts/p2p-trading/schema/execute_msg.json
@@ -259,6 +259,59 @@
     {
       "type": "object",
       "required": [
+        "set_n_f_ts_wanted"
+      ],
+      "properties": {
+        "set_n_f_ts_wanted": {
+          "type": "object",
+          "required": [
+            "nfts_wanted"
+          ],
+          "properties": {
+            "nfts_wanted": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "trade_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "flush_n_f_ts_wanted"
+      ],
+      "properties": {
+        "flush_n_f_ts_wanted": {
+          "type": "object",
+          "required": [
+            "trade_id"
+          ],
+          "properties": {
+            "trade_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
         "add_tokens_wanted"
       ],
       "properties": {
@@ -306,6 +359,59 @@
                 "$ref": "#/definitions/AssetInfo"
               }
             },
+            "trade_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "set_tokens_wanted"
+      ],
+      "properties": {
+        "set_tokens_wanted": {
+          "type": "object",
+          "required": [
+            "tokens_wanted"
+          ],
+          "properties": {
+            "tokens_wanted": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AssetInfo"
+              }
+            },
+            "trade_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "flush_tokens_wanted"
+      ],
+      "properties": {
+        "flush_tokens_wanted": {
+          "type": "object",
+          "required": [
+            "trade_id"
+          ],
+          "properties": {
             "trade_id": {
               "type": "integer",
               "format": "uint64",
@@ -575,26 +681,22 @@
       "additionalProperties": false
     },
     {
-      "description": "The fee contract can Withdraw funds via this function only when the trade is accepted.",
+      "description": "The trader or counter trader contract can Withdraw funds via this function only when the trade is accepted.",
       "type": "object",
       "required": [
-        "withdraw_pending_assets"
+        "withdraw_successful_trade"
       ],
       "properties": {
-        "withdraw_pending_assets": {
+        "withdraw_successful_trade": {
           "type": "object",
           "required": [
-            "trade_id",
-            "trader"
+            "trade_id"
           ],
           "properties": {
             "trade_id": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
-            },
-            "trader": {
-              "type": "string"
             }
           }
         }
@@ -676,17 +778,40 @@
     {
       "type": "object",
       "required": [
-        "set_new_fee_contract"
+        "set_new_treasury"
       ],
       "properties": {
-        "set_new_fee_contract": {
+        "set_new_treasury": {
           "type": "object",
           "required": [
-            "fee_contract"
+            "treasury"
           ],
           "properties": {
-            "fee_contract": {
+            "treasury": {
               "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "set_new_accept_fee"
+      ],
+      "properties": {
+        "set_new_accept_fee": {
+          "type": "object",
+          "required": [
+            "accept_fee"
+          ],
+          "properties": {
+            "accept_fee": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Coin"
+              }
             }
           }
         }
@@ -788,18 +913,6 @@
         {
           "type": "object",
           "required": [
-            "cw20_coin"
-          ],
-          "properties": {
-            "cw20_coin": {
-              "$ref": "#/definitions/Cw20Coin"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
             "cw721_coin"
           ],
           "properties": {
@@ -812,11 +925,11 @@
         {
           "type": "object",
           "required": [
-            "cw1155_coin"
+            "coin"
           ],
           "properties": {
-            "cw1155_coin": {
-              "$ref": "#/definitions/Cw1155Coin"
+            "coin": {
+              "$ref": "#/definitions/Coin"
             }
           },
           "additionalProperties": false
@@ -824,11 +937,11 @@
         {
           "type": "object",
           "required": [
-            "coin"
+            "sg721_token"
           ],
           "properties": {
-            "coin": {
-              "$ref": "#/definitions/Coin"
+            "sg721_token": {
+              "$ref": "#/definitions/Sg721Token"
             }
           },
           "additionalProperties": false
@@ -850,40 +963,6 @@
         }
       }
     },
-    "Cw1155Coin": {
-      "type": "object",
-      "required": [
-        "address",
-        "token_id",
-        "value"
-      ],
-      "properties": {
-        "address": {
-          "type": "string"
-        },
-        "token_id": {
-          "type": "string"
-        },
-        "value": {
-          "$ref": "#/definitions/Uint128"
-        }
-      }
-    },
-    "Cw20Coin": {
-      "type": "object",
-      "required": [
-        "address",
-        "amount"
-      ],
-      "properties": {
-        "address": {
-          "type": "string"
-        },
-        "amount": {
-          "$ref": "#/definitions/Uint128"
-        }
-      }
-    },
     "Cw721Coin": {
       "type": "object",
       "required": [
@@ -897,7 +976,24 @@
         "token_id": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "Sg721Token": {
+      "type": "object",
+      "required": [
+        "address",
+        "token_id"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "token_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/p2p-trading/schema/instantiate_msg.json
+++ b/contracts/p2p-trading/schema/instantiate_msg.json
@@ -3,9 +3,21 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
-    "name"
+    "accept_trade_fee",
+    "fund_fee",
+    "name",
+    "treasury"
   ],
   "properties": {
+    "accept_trade_fee": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Coin"
+      }
+    },
+    "fund_fee": {
+      "$ref": "#/definitions/Decimal"
+    },
     "name": {
       "type": "string"
     },
@@ -14,6 +26,34 @@
         "string",
         "null"
       ]
+    },
+    "treasury": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
     }
   }
 }

--- a/contracts/p2p-trading/src/contract.rs
+++ b/contracts/p2p-trading/src/contract.rs
@@ -3,16 +3,18 @@ use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
     StdResult,
 };
+use cosmwasm_std::{BankMsg, Coin};
 use cw2::set_contract_version;
+use utils::payment::assert_payment;
+use utils::state::AssetInfo;
 
 use crate::error::ContractError;
 
 use crate::state::{
-    is_fee_contract, is_owner, load_counter_trade, load_trade, CONTRACT_INFO, COUNTER_TRADE_INFO,
-    TRADE_INFO,
+    is_owner, load_counter_trade, load_trade, CONTRACT_INFO, COUNTER_TRADE_INFO, TRADE_INFO,
 };
 use p2p_trading_export::msg::{AddAssetAction, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
-use p2p_trading_export::state::{AssetInfo, ContractInfo, TradeState};
+use p2p_trading_export::state::{ContractInfo, TradeState};
 
 use crate::counter_trade::{
     add_asset_to_counter_trade, cancel_counter_trade, confirm_counter_trade, suggest_counter_trade,
@@ -21,9 +23,9 @@ use crate::counter_trade::{
 use crate::trade::{
     accept_trade, add_asset_to_trade, add_nfts_wanted, add_tokens_wanted, add_whitelisted_users,
     cancel_trade, check_and_create_withdraw_messages, confirm_trade, create_trade,
-    flush_nfts_wanted, flush_tokens_wanted, refuse_counter_trade, remove_nfts_wanted,
-    remove_tokens_wanted, remove_whitelisted_users, set_nfts_wanted, set_tokens_wanted,
-    withdraw_all_from_trade, withdraw_trade_assets_while_creating,
+    flush_nfts_wanted, flush_tokens_wanted, gather_royalties, refuse_counter_trade,
+    remove_nfts_wanted, remove_tokens_wanted, remove_whitelisted_users, set_nfts_wanted,
+    set_tokens_wanted, withdraw_all_from_trade, withdraw_trade_assets_while_creating,
 };
 
 use crate::messages::{review_counter_trade, set_comment, set_trade_preview};
@@ -47,14 +49,21 @@ pub fn instantiate(
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     msg.validate()?;
+
+    if msg.accept_trade_fee.iter().any(|c| c.amount.is_zero()) {
+        return Err(StdError::generic_err("Fee can't be zero").into());
+    }
+
     // store token info
     let data = ContractInfo {
         name: msg.name,
         owner: deps
             .api
             .addr_validate(&msg.owner.unwrap_or_else(|| info.sender.to_string()))?,
-        fee_contract: None,
         last_trade_id: None,
+        accept_trade_fee: msg.accept_trade_fee,
+        treasury: deps.api.addr_validate(&msg.treasury)?,
+        fund_fee: msg.fund_fee,
     };
     CONTRACT_INFO.save(deps.storage, &data)?;
     Ok(Response::default()
@@ -71,19 +80,16 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        // Trade Creation Messages
         ExecuteMsg::CreateTrade {
             whitelisted_users,
             comment,
         } => create_trade(deps, env, info, whitelisted_users, comment),
-
         ExecuteMsg::AddAsset { action, asset } => add_asset(deps, env, info, action, asset),
         ExecuteMsg::RemoveAssets {
             trade_id,
             counter_id,
             assets,
         } => withdraw_assets_while_creating(deps, env, info, trade_id, counter_id, assets),
-
         ExecuteMsg::AddWhitelistedUsers {
             trade_id,
             whitelisted_users,
@@ -95,114 +101,87 @@ pub fn execute(
             trade_id,
             whitelisted_users,
         ),
-
         ExecuteMsg::RemoveWhitelistedUsers {
             trade_id,
             whitelisted_users,
         } => remove_whitelisted_users(deps, env, info, trade_id, whitelisted_users),
-
         ExecuteMsg::AddNFTsWanted {
             trade_id,
             nfts_wanted,
         } => add_nfts_wanted(deps, env, info, trade_id, nfts_wanted),
-
         ExecuteMsg::RemoveNFTsWanted {
             trade_id,
             nfts_wanted,
         } => remove_nfts_wanted(deps, env, info, trade_id, nfts_wanted),
-
         ExecuteMsg::SetNFTsWanted {
             trade_id,
             nfts_wanted,
         } => set_nfts_wanted(deps, env, info, trade_id, nfts_wanted),
-
         ExecuteMsg::FlushNFTsWanted { trade_id } => flush_nfts_wanted(deps, env, info, trade_id),
-
         ExecuteMsg::AddTokensWanted {
             trade_id,
             tokens_wanted,
         } => add_tokens_wanted(deps, env, info, trade_id, tokens_wanted),
-
         ExecuteMsg::RemoveTokensWanted {
             trade_id,
             tokens_wanted,
         } => remove_tokens_wanted(deps, env, info, trade_id, tokens_wanted),
-
         ExecuteMsg::SetTokensWanted {
             trade_id,
             tokens_wanted,
         } => set_tokens_wanted(deps, env, info, trade_id, tokens_wanted),
-
         ExecuteMsg::FlushTokensWanted { trade_id } => {
             flush_tokens_wanted(deps, env, info, trade_id)
         }
-
         ExecuteMsg::SetTradePreview { action, asset } => {
             set_trade_preview(deps, env, info, action, asset)
         }
-
         ExecuteMsg::SetComment {
             trade_id,
             counter_id,
             comment,
         } => set_comment(deps, env, info, trade_id, counter_id, comment),
-
         ExecuteMsg::ConfirmTrade { trade_id } => confirm_trade(deps, env, info, trade_id),
-
-        //Counter Trade Creation Messages
         ExecuteMsg::SuggestCounterTrade { trade_id, comment } => {
             suggest_counter_trade(deps, env, info, trade_id, comment)
         }
-
         ExecuteMsg::ConfirmCounterTrade {
             trade_id,
             counter_id,
         } => confirm_counter_trade(deps, env, info, trade_id, counter_id),
-
-        // After Create Messages
         ExecuteMsg::AcceptTrade {
             trade_id,
             counter_id,
             comment,
         } => accept_trade(deps, env, info, trade_id, counter_id, comment),
-
-        // After Create Messages
         ExecuteMsg::CancelTrade { trade_id } => cancel_trade(deps, env, info, trade_id),
         ExecuteMsg::CancelCounterTrade {
             trade_id,
             counter_id,
         } => cancel_counter_trade(deps, env, info, trade_id, counter_id),
-
         ExecuteMsg::RefuseCounterTrade {
             trade_id,
             counter_id,
         } => refuse_counter_trade(deps, env, info, trade_id, counter_id),
-
         ExecuteMsg::ReviewCounterTrade {
             trade_id,
             counter_id,
             comment,
         } => review_counter_trade(deps, env, info, trade_id, counter_id, comment),
-
-        ExecuteMsg::WithdrawPendingAssets { trader, trade_id } => {
-            withdraw_accepted_funds(deps, env, info, trader, trade_id)
-        }
-
         ExecuteMsg::WithdrawAllFromTrade { trade_id } => {
             withdraw_all_from_trade(deps, env, info, trade_id)
         }
-
         ExecuteMsg::WithdrawAllFromCounter {
             trade_id,
             counter_id,
         } => withdraw_all_from_counter(deps, env, info, trade_id, counter_id),
-
-        // Contract Variable
         ExecuteMsg::SetNewOwner { owner } => set_new_owner(deps, env, info, owner),
-
-        // Contract Variable
-        ExecuteMsg::SetNewFeeContract { fee_contract } => {
-            set_new_fee_contract(deps, env, info, fee_contract)
+        ExecuteMsg::SetNewTreasury { treasury } => set_new_treasury(deps, env, info, treasury),
+        ExecuteMsg::SetNewAcceptFee { accept_fee } => {
+            set_new_accept_fee(deps, env, info, accept_fee)
+        }
+        ExecuteMsg::WithdrawSuccessfulTrade { trade_id } => {
+            withdraw_successful_trade(deps, env, info, trade_id)
         }
     }
 }
@@ -282,23 +261,46 @@ pub fn set_new_owner(
 }
 
 /// Replace the current fee_contract with the provided fee_contract address
-/// * `fee_contract` must be a valid Terra address
-pub fn set_new_fee_contract(
+/// * `treasury` must be a valid Terra address
+pub fn set_new_treasury(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    fee_contract: String,
+    treasury: String,
 ) -> Result<Response, ContractError> {
     let mut contract_info = is_owner(deps.storage, info.sender)?;
 
-    let fee_contract = deps.api.addr_validate(&fee_contract)?;
-    contract_info.fee_contract = Some(fee_contract.clone());
+    let treasury = deps.api.addr_validate(&treasury)?;
+    contract_info.treasury = treasury.clone();
     CONTRACT_INFO.save(deps.storage, &contract_info)?;
 
     Ok(Response::new()
         .add_attribute("action", "modify_parameter")
-        .add_attribute("parameter", "fee_contract")
-        .add_attribute("value", fee_contract))
+        .add_attribute("parameter", "treasury")
+        .add_attribute("value", treasury))
+}
+
+/// Replace the current fee price for accepting trades
+/// * `treasury` must be a valid Terra address
+pub fn set_new_accept_fee(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    accept_fee: Vec<Coin>,
+) -> Result<Response, ContractError> {
+    let mut contract_info = is_owner(deps.storage, info.sender)?;
+
+    if accept_fee.iter().any(|c| c.amount.is_zero()) {
+        return Err(StdError::generic_err("Fee can't be zero").into());
+    }
+
+    contract_info.accept_trade_fee.clone_from(&accept_fee);
+    CONTRACT_INFO.save(deps.storage, &contract_info)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "modify_parameter")
+        .add_attribute("parameter", "accept_fee_possibilities")
+        .add_attribute("value", format!("{:?}", accept_fee)))
 }
 
 /// General handler to add an asset to a trade or a counter trade
@@ -346,21 +348,21 @@ pub fn withdraw_assets_while_creating(
 /// Withdraw assets from an accepted trade.
 /// The trader will withdraw assets from the counter_trade
 /// The counter_trader will withdraw assets from the trade
-pub fn withdraw_accepted_funds(
+pub fn withdraw_successful_trade(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    trader: String,
     trade_id: u64,
 ) -> Result<Response, ContractError> {
-    // The fee contract is the only one responsible for withdrawing assets
-    is_fee_contract(deps.storage, info.sender)?;
-
     // We load the trade and verify it has been accepted
     let mut trade_info = load_trade(deps.storage, trade_id)?;
     if trade_info.state != TradeState::Accepted {
         return Err(ContractError::TradeNotAccepted {});
     }
+
+    let contract_info = CONTRACT_INFO.load(deps.storage)?;
+    // We check that they pay the right fee
+    let funds = assert_payment(&info, contract_info.accept_trade_fee)?;
 
     // We load the corresponding counter_trade
     let counter_id = trade_info
@@ -370,20 +372,33 @@ pub fn withdraw_accepted_funds(
         .counter_id;
     let mut counter_info = load_counter_trade(deps.storage, trade_id, counter_id)?;
 
-    let trader = deps.api.addr_validate(&trader)?;
     let (res, trade_type);
 
     // We indentify who the transaction sender is (trader or counter-trader)
-    if trade_info.owner == trader {
+    if trade_info.owner == info.sender {
         // In case the trader wants to withdraw the exchanged funds (from the counter_info object)
-        res = check_and_create_withdraw_messages(env, &trader, &counter_info)?;
+        let royalties = gather_royalties(deps.as_ref(), &trade_info)?;
+        res = check_and_create_withdraw_messages(
+            deps.as_ref(),
+            &info.sender,
+            &counter_info,
+            Some(royalties),
+            Some(contract_info.fund_fee),
+        )?;
 
         trade_type = "counter";
         counter_info.assets_withdrawn = true;
         COUNTER_TRADE_INFO.save(deps.storage, (trade_id, counter_id), &counter_info)?;
-    } else if counter_info.owner == trader {
+    } else if counter_info.owner == info.sender {
         // In case the counter_trader wants to withdraw the exchanged funds (from the trade_info object)
-        res = check_and_create_withdraw_messages(env, &trader, &trade_info)?;
+        let royalties = gather_royalties(deps.as_ref(), &counter_info)?;
+        res = check_and_create_withdraw_messages(
+            deps.as_ref(),
+            &info.sender,
+            &trade_info,
+            Some(royalties),
+            Some(contract_info.fund_fee),
+        )?;
 
         trade_type = "trade";
         trade_info.assets_withdrawn = true;
@@ -393,6 +408,10 @@ pub fn withdraw_accepted_funds(
     }
 
     Ok(res
+        .add_message(BankMsg::Send {
+            to_address: contract_info.treasury.to_string(),
+            amount: vec![funds],
+        })
         .add_attribute("action", "withdraw_funds")
         .add_attribute("type", trade_type)
         .add_attribute("trade_id", trade_id.to_string())
@@ -406,17 +425,19 @@ pub mod tests {
     use super::*;
     use crate::state::load_trade;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coins, Addr, Attribute, BankMsg, Coin, Uint128};
+    use cosmwasm_std::{coins, Addr, Attribute, BankMsg, Coin, Decimal, Uint128};
     use cw1155::Cw1155ExecuteMsg;
     use cw20::Cw20ExecuteMsg;
     use cw721::Cw721ExecuteMsg;
     use p2p_trading_export::msg::into_cosmos_msg;
-    use p2p_trading_export::state::{AssetInfo, Cw1155Coin, Cw20Coin, Cw721Coin};
 
     fn init_helper(deps: DepsMut) {
         let instantiate_msg = InstantiateMsg {
             name: "p2p-trading".to_string(),
             owner: None,
+            accept_trade_fee: coins(2367, "ujuno"),
+            treasury: "treasury".to_string(),
+            fund_fee: Decimal::percent(3),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -424,15 +445,15 @@ pub mod tests {
         instantiate(deps, env, info, instantiate_msg).unwrap();
     }
 
-    fn set_fee_contract_helper(deps: DepsMut) {
+    fn set_treasury_helper(deps: DepsMut) {
         let info = mock_info("creator", &[]);
         let env = mock_env();
         execute(
             deps,
             env,
             info,
-            ExecuteMsg::SetNewFeeContract {
-                fee_contract: "fee_contract".to_string(),
+            ExecuteMsg::SetNewTreasury {
+                treasury: "treasury".to_string(),
             },
         )
         .unwrap();
@@ -444,6 +465,9 @@ pub mod tests {
         let instantiate_msg = InstantiateMsg {
             name: "p2p-trading".to_string(),
             owner: Some("this_address".to_string()),
+            accept_trade_fee: coins(2367, "ujuno"),
+            treasury: "treasury".to_string(),
+            fund_fee: Decimal::percent(3),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -660,26 +684,6 @@ pub mod tests {
         )
     }
 
-    fn withdraw_helper(
-        deps: DepsMut,
-        trader: &str,
-        sender: &str,
-        trade_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(sender, &[]);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::WithdrawPendingAssets {
-                trader: trader.to_string(),
-                trade_id,
-            },
-        )
-    }
-
     fn withdraw_cancelled_trade_helper(
         deps: DepsMut,
         sender: &str,
@@ -716,3558 +720,3308 @@ pub mod tests {
         )
     }
 
-    pub mod trade_tests {
-        use super::*;
-        use crate::query::{query_counter_trades, TradeResponse};
-        use crate::trade::validate_addresses;
-        use cosmwasm_std::{coin, Api, SubMsg};
-        use p2p_trading_export::msg::{
-            AdditionalTradeInfoResponse, QueryFilters, TradeInfoResponse,
-        };
-        use p2p_trading_export::state::{Comment, CounterTradeInfo};
-        use std::collections::HashSet;
-        use std::iter::FromIterator;
-
-        #[test]
-        fn create_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            let res = create_trade_helper(deps.as_mut(), "creator");
-
-            assert_eq!(res.messages, vec![]);
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "create_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            let res = create_trade_helper(deps.as_mut(), "creator");
-
-            assert_eq!(res.messages, vec![]);
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "create_trade"),
-                    Attribute::new("trade_id", "1"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-
-            assert_eq!(new_trade_info.state, TradeState::Created {});
-
-            // Query all and check that trades exist, without filters specified
-            let res = query_all_trades(deps.as_ref(), None, None, None).unwrap();
-
-            assert_eq!(
-                res.trades,
-                vec![
-                    {
-                        TradeResponse {
-                            trade_id: 1,
-                            counter_id: None,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("creator").unwrap(),
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: mock_env().block.time,
-                                    }),
-                                    time: mock_env().block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    },
-                    {
-                        TradeResponse {
-                            trade_id: 0,
-                            counter_id: None,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("creator").unwrap(),
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: mock_env().block.time,
-                                    }),
-                                    time: mock_env().block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    }
-                ]
-            );
-        }
-
-        #[test]
-        fn create_trade_and_nfts_wanted() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            let res = add_nfts_wanted_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                vec!["nft1".to_string(), "nft2".to_string()],
-            )
-            .unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "modify_parameter"),
-                    Attribute::new("name", "nfts_wanted"),
-                    Attribute::new("operation_type", "add"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator")
-                ]
-            );
-
-            let trade = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                trade.additional_info.nfts_wanted,
-                HashSet::from_iter(vec![Addr::unchecked("nft1"), Addr::unchecked("nft2")])
-            );
-
-            add_nfts_wanted_helper(deps.as_mut(), "creator", 0, vec!["nft1".to_string()]).unwrap();
-            remove_nfts_wanted_helper(deps.as_mut(), "creator", 0, vec!["nft1".to_string()])
-                .unwrap();
-
-            let trade = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                trade.additional_info.nfts_wanted,
-                HashSet::from_iter(vec![Addr::unchecked("nft2")])
-            );
-        }
-
-        #[test]
-        fn create_multiple_trades_and_query() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            let res = create_trade_helper(deps.as_mut(), "creator");
-
-            assert_eq!(res.messages, vec![]);
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "create_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            let res = create_trade_helper(deps.as_mut(), "creator2");
-
-            assert_eq!(res.messages, vec![]);
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "create_trade"),
-                    Attribute::new("trade_id", "1"),
-                    Attribute::new("trader", "creator2"),
-                ]
-            );
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-
-            assert_eq!(new_trade_info.state, TradeState::Created {});
-
-            let new_trade_info = load_trade(&deps.storage, 1).unwrap();
-            assert_eq!(new_trade_info.state, TradeState::Created {});
-
-            create_trade_helper(deps.as_mut(), "creator2");
-            confirm_trade_helper(deps.as_mut(), "creator2", 2).unwrap();
-
-            // Query all created trades check that creators are different
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Created.to_string()]),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.trades,
-                vec![
-                    {
-                        TradeResponse {
-                            trade_id: 1,
-                            counter_id: None,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("creator2").unwrap(),
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: mock_env().block.time,
-                                    }),
-                                    time: mock_env().block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    },
-                    {
-                        TradeResponse {
-                            trade_id: 0,
-                            counter_id: None,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("creator").unwrap(),
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: mock_env().block.time,
-                                    }),
-                                    time: mock_env().block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    }
-                ]
-            );
-
-            // Verify that pagination by trade_id works
-            let res = query_all_trades(
-                deps.as_ref(),
-                Some(1),
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Created.to_string()]),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.trades,
-                vec![{
-                    TradeResponse {
-                        trade_id: 0,
-                        counter_id: None,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("creator").unwrap(),
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-
-            // Query that query returned only queries that are in created state and belong to creator2
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Created.to_string()]),
-                    owner: Some("creator2".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.trades,
-                vec![TradeResponse {
-                    trade_id: 1,
-                    counter_id: None,
-                    trade_info: Some(TradeInfoResponse {
-                        owner: deps.api.addr_validate("creator2").unwrap(),
-                        additional_info: AdditionalTradeInfoResponse {
-                            owner_comment: Some(Comment {
-                                comment: "Q".to_string(),
-                                time: mock_env().block.time
-                            }),
-                            time: mock_env().block.time,
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    })
-                }]
-            );
-
-            // Check that if states are None that owner query still works
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    owner: Some("creator2".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.trades,
-                vec![
-                    TradeResponse {
-                        trade_id: 2,
-                        counter_id: None,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("creator2").unwrap(),
-                            state: TradeState::Published,
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                    },
-                    TradeResponse {
-                        trade_id: 1,
-                        counter_id: None,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("creator2").unwrap(),
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                    }
-                ]
-            );
-
-            // Check that queries with published state do not return anything. Because none exists.
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Accepted.to_string()]),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(res.trades, vec![]);
-
-            // Check that queries with published state do not return anything when owner is specified. Because none exists.
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Accepted.to_string()]),
-                    owner: Some("creator2".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-            assert_eq!(res.trades, vec![]);
-        }
-
-        #[test]
-        fn create_trade_and_add_funds() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            let res = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(2, "token")),
-                &coins(2, "token"),
-            )
-            .unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "add_asset"),
-                    Attribute::new("asset_type", "fund"),
-                    Attribute::new("denom", "token"),
-                    Attribute::new("amount", "2"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(2, "token")),
-                &coins(2, "token"),
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(2, "other_token")),
-                &coins(2, "other_token"),
-            )
-            .unwrap();
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![
-                    AssetInfo::Coin(Coin {
-                        amount: Uint128::from(4u64),
-                        denom: "token".to_string()
-                    }),
-                    AssetInfo::Coin(Coin {
-                        amount: Uint128::from(2u64),
-                        denom: "other_token".to_string()
-                    })
-                ]
-            );
-        }
-
-        #[test]
-        fn create_trade_and_add_cw20_tokens() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            let res = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "add_asset"),
-                    Attribute::new("asset_type", "token"),
-                    Attribute::new("token", "token"),
-                    Attribute::new("amount", "100"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "other_token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        amount: Uint128::from(200u64),
-                        address: "token".to_string()
-                    }),
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        amount: Uint128::from(100u64),
-                        address: "other_token".to_string()
-                    })
-                ]
-            );
-
-            // Verify the token contain query
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    contains_token: Some("other_token".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            let env = mock_env();
-            assert_eq!(
-                res.trades,
-                vec![{
-                    TradeResponse {
-                        trade_id: 0,
-                        counter_id: None,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("creator").unwrap(),
-                            state: TradeState::Created,
-                            associated_assets: vec![
-                                AssetInfo::Cw20Coin(Cw20Coin {
-                                    amount: Uint128::from(200u64),
-                                    address: "token".to_string(),
-                                }),
-                                AssetInfo::Cw20Coin(Cw20Coin {
-                                    amount: Uint128::from(100u64),
-                                    address: "other_token".to_string(),
-                                }),
-                            ],
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: env.block.time,
-                                }),
-                                time: env.block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-
-            // Verify it works when querying another token
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    contains_token: Some("bad_token".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-            assert_eq!(res.trades, vec![]);
-
-            // This triggers an error, the creator is not the same as the sender
-
-            let err = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "bad_person",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "other_token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::TraderNotCreator {});
-        }
-
-        #[test]
-        fn create_trade_and_add_cw721_tokens() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            let res = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "add_asset"),
-                    Attribute::new("asset_type", "NFT"),
-                    Attribute::new("nft", "nft"),
-                    Attribute::new("token_id", "58"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![AssetInfo::Cw721Coin(Cw721Coin {
-                    token_id: "58".to_string(),
-                    address: "nft".to_string()
-                })]
-            );
-
-            // This triggers an error, the creator is not the same as the sender
-            let err = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "bad_person",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "other_token".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::TraderNotCreator {});
-        }
-
-        #[test]
-        fn create_trade_and_add_cw1155_tokens() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            let res = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw1155Coin(Cw1155Coin {
-                    address: "1155".to_string(),
-                    token_id: "58".to_string(),
-                    value: Uint128::new(50u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "add_asset"),
-                    Attribute::new("asset_type", "cw1155"),
-                    Attribute::new("token", "1155"),
-                    Attribute::new("token_id", "58"),
-                    Attribute::new("amount", "50"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![AssetInfo::Cw1155Coin(Cw1155Coin {
-                    token_id: "58".to_string(),
-                    address: "1155".to_string(),
-                    value: Uint128::from(50u128)
-                })]
-            );
-
-            // This triggers an error, the creator is not the same as the sender
-            let err = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "bad_person",
-                0,
-                AssetInfo::Cw1155Coin(Cw1155Coin {
-                    address: "1155".to_string(),
-                    token_id: "58".to_string(),
-                    value: Uint128::new(50u128),
-                }),
-                &[],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::TraderNotCreator {});
-        }
-        #[test]
-        fn create_trade_and_withdraw() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            create_trade_helper(deps.as_mut(), "creator");
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw1155Coin(Cw1155Coin {
-                    address: "1155".to_string(),
-                    token_id: "58".to_string(),
-                    value: Uint128::new(50u128),
-                }),
-                &[],
-            )
-            .unwrap();
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "other_token".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            withdraw_cancelled_trade_helper(deps.as_mut(), "bas_person", 0).unwrap_err();
-            withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(new_trade_info.state, TradeState::Cancelled);
-
-            withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
-        }
-        #[test]
-        fn create_trade_automatic_trade_id() {
-            let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
-            let env = mock_env();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            create_trade_helper(deps.as_mut(), "creator");
-
-            execute(
-                deps.as_mut(),
-                env.clone(),
-                info,
-                ExecuteMsg::AddAsset {
-                    action: AddAssetAction::ToLastTrade {},
-                    asset: AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "cw20".to_string(),
-                        amount: Uint128::from(100u64),
-                    }),
-                },
-            )
-            .unwrap();
-
-            let info = mock_info("creator", &coins(97u128, "uluna"));
-            execute(
-                deps.as_mut(),
-                env,
-                info,
-                ExecuteMsg::AddAsset {
-                    action: AddAssetAction::ToLastTrade {},
-                    asset: AssetInfo::Coin(coin(97u128, "uluna")),
-                },
-            )
-            .unwrap();
-
-            let trade_info = TRADE_INFO.load(&deps.storage, 1u64).unwrap();
-            assert_eq!(
-                trade_info.associated_assets,
-                vec![
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "cw20".to_string(),
-                        amount: Uint128::from(100u128)
-                    }),
-                    AssetInfo::Coin(coin(97u128, "uluna")),
-                ]
-            );
-        }
-
-        #[test]
-        fn create_trade_add_remove_tokens() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft-2".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw1155Coin(Cw1155Coin {
-                    address: "cw1155token".to_string(),
-                    token_id: "58".to_string(),
-                    value: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(100, "luna")),
-                &coins(100, "luna"),
-            )
-            .unwrap();
-
-            let res = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![
-                    (
-                        0,
-                        AssetInfo::Cw721Coin(Cw721Coin {
-                            address: "nft".to_string(),
-                            token_id: "58".to_string(),
-                        }),
-                    ),
-                    (
-                        2,
-                        AssetInfo::Cw1155Coin(Cw1155Coin {
-                            address: "cw1155token".to_string(),
-                            token_id: "58".to_string(),
-                            value: Uint128::from(58u128),
-                        }),
-                    ),
-                    (
-                        3,
-                        AssetInfo::Cw20Coin(Cw20Coin {
-                            address: "token".to_string(),
-                            amount: Uint128::from(58u64),
-                        }),
-                    ),
-                    (4, AssetInfo::Coin(coin(58, "luna"))),
-                ],
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.messages,
-                vec![
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw721ExecuteMsg::TransferNft {
-                                recipient: "creator".to_string(),
-                                token_id: "58".to_string()
-                            },
-                            "nft"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw1155ExecuteMsg::SendFrom {
-                                from: mock_env().contract.address.to_string(),
-                                to: "creator".to_string(),
-                                token_id: "58".to_string(),
-                                value: Uint128::from(58u128),
-                                msg: None
-                            },
-                            "cw1155token"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw20ExecuteMsg::Transfer {
-                                recipient: "creator".to_string(),
-                                amount: Uint128::from(58u64)
-                            },
-                            "token"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(BankMsg::Send {
-                        to_address: "creator".to_string(),
-                        amount: coins(58, "luna"),
-                    })
-                ]
-            );
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        token_id: "58".to_string(),
-                        address: "nft-2".to_string()
-                    }),
-                    AssetInfo::Cw1155Coin(Cw1155Coin {
-                        value: Uint128::from(42u64),
-                        address: "cw1155token".to_string(),
-                        token_id: "58".to_string()
-                    }),
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        amount: Uint128::from(42u64),
-                        address: "token".to_string()
-                    }),
-                    AssetInfo::Coin(coin(42, "luna"))
-                ],
-            );
-
-            remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![
-                    (
-                        1,
-                        AssetInfo::Cw1155Coin(Cw1155Coin {
-                            address: "cw1155token".to_string(),
-                            token_id: "58".to_string(),
-                            value: Uint128::from(42u64),
-                        }),
-                    ),
-                    (
-                        2,
-                        AssetInfo::Cw20Coin(Cw20Coin {
-                            address: "token".to_string(),
-                            amount: Uint128::from(42u64),
-                        }),
-                    ),
-                    (3, AssetInfo::Coin(coin(42, "luna"))),
-                ],
-            )
-            .unwrap();
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![AssetInfo::Cw721Coin(Cw721Coin {
-                    token_id: "58".to_string(),
-                    address: "nft-2".to_string()
-                }),],
-            );
-
-            // This triggers an error, the creator is not the same as the sender
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "bad_person",
-                0,
-                None,
-                vec![(
-                    0,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-2".to_string(),
-                        token_id: "58".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::TraderNotCreator {});
-
-            // This triggers an error, no matching funds were found
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![(
-                    1,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-2".to_string(),
-                        token_id: "58".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 1 });
-
-            // This triggers an error, no matching funds were found
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![(
-                    0,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-1".to_string(),
-                        token_id: "58".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 0 });
-
-            // This triggers an error, no matching funds were found
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![(
-                    0,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-2".to_string(),
-                        token_id: "42".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 0 });
-        }
-
-        #[test]
-        fn create_trade_add_remove_tokens_errors() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft-2".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(100, "luna")),
-                &coins(100, "luna"),
-            )
-            .unwrap();
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![(
-                    2,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "token".to_string(),
-                        amount: Uint128::from(101u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(
-                err,
-                ContractError::TooMuchWithdrawn {
-                    address: "token".to_string(),
-                    wanted: 101,
-                    available: 100
-                }
-            );
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![(
-                    0,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "token".to_string(),
-                        amount: Uint128::from(101u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 0 });
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![(
-                    2,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "wrong-token".to_string(),
-                        amount: Uint128::from(101u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 2 });
-
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                None,
-                vec![(
-                    2,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "token".to_string(),
-                        amount: Uint128::from(58u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::TradeAlreadyPublished {});
-        }
-
-        #[test]
-        fn confirm_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            //Wrong trade id
-            let err = confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInTradeInfo {});
-
-            //Wrong trader
-            let err = confirm_trade_helper(deps.as_mut(), "bad_person", 0).unwrap_err();
-            assert_eq!(err, ContractError::TraderNotCreator {});
-
-            let res = confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "confirm_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            // Check with query that trade is confirmed, in published state
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Published.to_string()]),
-                    owner: Some("creator".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.trades,
-                vec![{
-                    TradeResponse {
-                        trade_id: 0,
-                        counter_id: None,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("creator").unwrap(),
-                            state: TradeState::Published,
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(new_trade_info.state, TradeState::Published {});
-
-            //Already confirmed
-            let err = confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
-            assert_eq!(
-                err,
-                ContractError::CantChangeTradeState {
-                    from: TradeState::Published,
-                    to: TradeState::Published
-                }
-            );
-        }
-
-        #[test]
-        fn confirm_trade_and_try_add_assets() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            // This triggers an error, we can't send funds to confirmed trade
-
-            let err = add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(2, "token")),
-                &coins(2, "token"),
-            )
-            .unwrap_err();
-
-            assert_eq!(
-                err,
-                ContractError::WrongTradeState {
-                    state: TradeState::Published
-                }
-            );
-        }
-
-        #[test]
-        fn accept_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            let err = accept_trade_helper(deps.as_mut(), "creator", 0, 5).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
-
-            let err = accept_trade_helper(deps.as_mut(), "creator", 1, 0).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInTradeInfo {});
-
-            let err = accept_trade_helper(deps.as_mut(), "bad_person", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::TraderNotCreator {});
-
-            let err = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::CantAcceptNotPublishedCounter {});
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-
-            let res = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "accept_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            let trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(trade_info.state, TradeState::Accepted {});
-            assert_eq!(
-                trade_info.accepted_info.unwrap(),
-                CounterTradeInfo {
-                    trade_id: 0,
-                    counter_id: 0
-                }
-            );
-
-            let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
-            assert_eq!(counter_trade_info.state, TradeState::Accepted {});
-
-            // Check with query that trade is confirmed, in ack state
-            let res = query_all_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Accepted.to_string()]),
-                    owner: Some("creator".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.trades,
-                vec![{
-                    TradeResponse {
-                        trade_id: 0,
-                        counter_id: None,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("creator").unwrap(),
-                            state: TradeState::Accepted,
-                            last_counter_id: Some(0),
-                            accepted_info: Some(CounterTradeInfo {
-                                trade_id: 0,
-                                counter_id: 0,
-                            }),
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-
-            // Check with query by trade id that one counter is returned
-            let res = query_counter_trades(deps.as_ref(), 0, None, None, None).unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![{
-                    TradeResponse {
-                        counter_id: Some(0),
-                        trade_id: 0,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("counterer").unwrap(),
-                            state: TradeState::Accepted,
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                trader_comment: Some(Comment {
-                                    comment: "You're very kind madam".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-
-            let res = query_counter_trades(deps.as_ref(), 0, Some(0), None, None).unwrap();
-            assert_eq!(res.counter_trades, vec![]);
-
-            // Check with queries that only one counter is returned by query and in accepted state
-            let res = query_all_counter_trades(deps.as_ref(), None, None, None).unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![{
-                    TradeResponse {
-                        counter_id: Some(0),
-                        trade_id: 0,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("counterer").unwrap(),
-                            state: TradeState::Accepted,
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                trader_comment: Some(Comment {
-                                    comment: "You're very kind madam".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-        }
-
-        #[test]
-        fn accept_trade_with_multiple_counter() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 1).unwrap();
-
-            let res = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "accept_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            let trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(trade_info.state, TradeState::Accepted {});
-
-            let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
-            assert_eq!(counter_trade_info.state, TradeState::Accepted {});
-
-            let counter_trade_info = load_counter_trade(&deps.storage, 0, 1).unwrap();
-            assert_eq!(counter_trade_info.state, TradeState::Refused {});
-
-            // Check that the only Accepted and Published counters are the accepted counter
-            let res = query_all_counter_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![
-                        TradeState::Accepted.to_string(),
-                        TradeState::Published.to_string(),
-                    ]),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![{
-                    TradeResponse {
-                        counter_id: Some(0),
-                        trade_id: 0,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("counterer").unwrap(),
-                            state: TradeState::Accepted,
-
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                trader_comment: Some(Comment {
-                                    comment: "You're very kind madam".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-            // Check that the other counters is cancelled
-            let res = query_all_counter_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![TradeState::Refused.to_string()]),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![
-                    {
-                        TradeResponse {
-                            counter_id: Some(2),
-                            trade_id: 0,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("counterer").unwrap(),
-                                state: TradeState::Refused,
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: mock_env().block.time,
-                                    }),
-                                    time: mock_env().block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    },
-                    {
-                        TradeResponse {
-                            counter_id: Some(1),
-                            trade_id: 0,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("counterer").unwrap(),
-                                state: TradeState::Refused,
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: mock_env().block.time,
-                                    }),
-                                    time: mock_env().block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    },
-                ]
-            );
-
-            // Check that both Accepted and Published counter queries exist, paginate to skip last counter trade
-            let res = query_all_counter_trades(
-                deps.as_ref(),
-                Some(CounterTradeInfo {
-                    trade_id: 0,
-                    counter_id: 1,
-                }),
-                None,
-                Some(QueryFilters {
-                    states: Some(vec![
-                        TradeState::Accepted.to_string(),
-                        TradeState::Published.to_string(),
-                    ]),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![{
-                    TradeResponse {
-                        counter_id: Some(0),
-                        trade_id: 0,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("counterer").unwrap(),
-                            state: TradeState::Accepted,
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                trader_comment: Some(Comment {
-                                    comment: "You're very kind madam".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-        }
-
-        #[test]
-        fn cancel_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            let err = cancel_trade_helper(deps.as_mut(), "creator", 1).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInTradeInfo {});
-
-            let err = cancel_trade_helper(deps.as_mut(), "bad_person", 0).unwrap_err();
-            assert_eq!(err, ContractError::TraderNotCreator {});
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-
-            let res = cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "cancel_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("trader", "creator"),
-                ]
-            );
-
-            // Query all counter trades make sure counter trade is cancelled with the trade
-            let res = query_all_counter_trades(deps.as_ref(), None, None, None).unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![{
-                    TradeResponse {
-                        counter_id: Some(0),
-                        trade_id: 0,
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("counterer").unwrap(),
-                            state: TradeState::Cancelled,
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time,
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    }
-                }]
-            );
-        }
-
-        #[test]
-        fn queries_with_multiple_trades_and_counter_trades() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap();
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 2).unwrap();
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 3).unwrap();
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 4).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer2", 0).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 1).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 2).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 3).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 4).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer2", 4).unwrap();
-
-            // Query all before second one, should return the first one
-            let res = query_all_counter_trades(
-                deps.as_ref(),
-                Some(CounterTradeInfo {
-                    trade_id: 0,
-                    counter_id: 1,
-                }),
-                None,
-                Some(QueryFilters {
-                    owner: Some("counterer2".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![TradeResponse {
-                    trade_id: 0,
-                    counter_id: Some(0),
-                    trade_info: Some(TradeInfoResponse {
-                        owner: deps.api.addr_validate("counterer2").unwrap(),
-                        state: TradeState::Created,
-                        additional_info: AdditionalTradeInfoResponse {
-                            owner_comment: Some(Comment {
-                                comment: "Q".to_string(),
-                                time: mock_env().block.time
-                            }),
-                            time: mock_env().block.time,
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    })
-                }]
-            );
-
-            // Query all before first one, should return empty array
-            let res = query_all_counter_trades(
-                deps.as_ref(),
-                Some(CounterTradeInfo {
-                    trade_id: 0,
-                    counter_id: 0,
-                }),
-                None,
-                None,
-            )
-            .unwrap();
-
-            assert_eq!(res.counter_trades, vec![]);
-
-            // Query for non existing user should return empty []
-            let res = query_all_counter_trades(
-                deps.as_ref(),
-                None,
-                None,
-                Some(QueryFilters {
-                    owner: Some("counterer5".to_string()),
-                    ..Default::default()
-                }),
-            )
-            .unwrap();
-
-            assert_eq!(res.counter_trades, vec![]);
-
-            // Query by trade_id should return counter queries for trade id 4
-            let res = query_counter_trades(deps.as_ref(), 4, None, None, None).unwrap();
-
-            assert_eq!(
-                res.counter_trades,
-                vec![
-                    TradeResponse {
-                        trade_id: 4,
-                        counter_id: Some(1),
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("counterer2").unwrap(),
-                            state: TradeState::Created,
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                    },
-                    TradeResponse {
-                        trade_id: 4,
-                        counter_id: Some(0),
-                        trade_info: Some(TradeInfoResponse {
-                            owner: deps.api.addr_validate("counterer").unwrap(),
-                            additional_info: AdditionalTradeInfoResponse {
-                                owner_comment: Some(Comment {
-                                    comment: "Q".to_string(),
-                                    time: mock_env().block.time
-                                }),
-                                time: mock_env().block.time,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                    }
-                ]
-            );
-        }
-
-        #[test]
-        fn withdraw_accepted_assets() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-            set_fee_contract_helper(deps.as_mut());
-            create_trade_helper(deps.as_mut(), "creator");
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw1155Coin(Cw1155Coin {
-                    address: "cw1155".to_string(),
-                    token_id: "58".to_string(),
-                    value: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(9, "other_token")),
-                &coins(9, "other_token"),
-            )
-            .unwrap();
-
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "other_counterer", 0).unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "other_counterer",
-                0,
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "other_counter-nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "other_counterer",
-                0,
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "other_counter-token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "other_counterer",
-                0,
-                0,
-                AssetInfo::Coin(coin(5, "lunas")),
-                &coins(5, "lunas"),
-            )
-            .unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                1,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "counter-nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                1,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "counter-token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                1,
-                AssetInfo::Coin(coin(2, "token")),
-                &coins(2, "token"),
-            )
-            .unwrap();
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 1).unwrap();
-
-            // Little test to start with (can't withdraw if the trade is not accepted)
-            let err = withdraw_helper(deps.as_mut(), "anyone", "fee_contract", 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeNotAccepted {});
-
-            accept_trade_helper(deps.as_mut(), "creator", 0, 1).unwrap();
-
-            // Withdraw tests
-            let err = withdraw_helper(deps.as_mut(), "bad_person", "fee_contract", 0).unwrap_err();
-            assert_eq!(err, ContractError::NotWithdrawableByYou {});
-
-            let err = withdraw_helper(deps.as_mut(), "creator", "bad_person", 0).unwrap_err();
-            assert_eq!(err, ContractError::Unauthorized {});
-
-            let res = withdraw_helper(deps.as_mut(), "creator", "fee_contract", 0).unwrap();
-            assert_eq!(
-                res.messages,
-                vec![
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw721ExecuteMsg::TransferNft {
-                                recipient: "creator".to_string(),
-                                token_id: "58".to_string()
-                            },
-                            "counter-nft"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw20ExecuteMsg::Transfer {
-                                recipient: "creator".to_string(),
-                                amount: Uint128::from(100u64)
-                            },
-                            "counter-token"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(BankMsg::Send {
-                        to_address: "creator".to_string(),
-                        amount: coins(2, "token"),
-                    })
-                ]
-            );
-
-            let err = withdraw_helper(deps.as_mut(), "creator", "fee_contract", 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
-
-            let res = withdraw_helper(deps.as_mut(), "counterer", "fee_contract", 0).unwrap();
-            assert_eq!(
-                res.messages,
-                vec![
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw721ExecuteMsg::TransferNft {
-                                recipient: "counterer".to_string(),
-                                token_id: "58".to_string()
-                            },
-                            "nft"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw1155ExecuteMsg::SendFrom {
-                                to: "counterer".to_string(),
-                                from: mock_env().contract.address.to_string(),
-                                token_id: "58".to_string(),
-                                value: Uint128::from(100u128),
-                                msg: None
-                            },
-                            "cw1155"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw20ExecuteMsg::Transfer {
-                                recipient: "counterer".to_string(),
-                                amount: Uint128::from(100u64)
-                            },
-                            "token"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(BankMsg::Send {
-                        to_address: "counterer".to_string(),
-                        amount: coins(9, "other_token"),
-                    }),
-                ]
-            );
-
-            let err = withdraw_helper(deps.as_mut(), "counterer", "fee_contract", 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
-
-            let res =
-                withdraw_aborted_counter_helper(deps.as_mut(), "other_counterer", 0, 0).unwrap();
-            assert_eq!(
-                res.messages,
-                vec![
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw721ExecuteMsg::TransferNft {
-                                recipient: "other_counterer".to_string(),
-                                token_id: "58".to_string()
-                            },
-                            "other_counter-nft"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw20ExecuteMsg::Transfer {
-                                recipient: "other_counterer".to_string(),
-                                amount: Uint128::from(100u64)
-                            },
-                            "other_counter-token"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(BankMsg::Send {
-                        to_address: "other_counterer".to_string(),
-                        amount: coins(5, "lunas"),
-                    }),
-                ]
-            );
-
-            let err = withdraw_aborted_counter_helper(deps.as_mut(), "other_counterer", 0, 0)
-                .unwrap_err();
-            assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
-        }
-
-        #[test]
-        fn withdraw_cancelled_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-            create_trade_helper(deps.as_mut(), "creator");
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(5, "lunas")),
-                &coins(5, "lunas"),
-            )
-            .unwrap();
-
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "other_counter-token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            let res = withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            assert_eq!(
-                res.messages,
-                vec![
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw721ExecuteMsg::TransferNft {
-                                recipient: "creator".to_string(),
-                                token_id: "58".to_string()
-                            },
-                            "nft"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw20ExecuteMsg::Transfer {
-                                recipient: "creator".to_string(),
-                                amount: Uint128::from(100u64)
-                            },
-                            "token"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(BankMsg::Send {
-                        to_address: "creator".to_string(),
-                        amount: coins(5, "lunas"),
-                    }),
-                ]
-            );
-
-            let err = withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
-
-            let res = withdraw_aborted_counter_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            assert_eq!(
-                res.messages,
-                vec![SubMsg::new(
-                    into_cosmos_msg(
-                        Cw20ExecuteMsg::Transfer {
-                            recipient: "counterer".to_string(),
-                            amount: Uint128::from(100u64)
-                        },
-                        "other_counter-token"
-                    )
-                    .unwrap()
-                ),]
-            );
-
-            let err =
-                withdraw_aborted_counter_helper(deps.as_mut(), "counterer", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
-        }
-
-        #[test]
-        fn private() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-            create_private_trade_helper(deps.as_mut(), vec!["whitelist".to_string()]);
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_trade_helper(
-                deps.as_mut(),
-                "creator",
-                0,
-                AssetInfo::Coin(coin(5, "lunas")),
-                &coins(5, "lunas"),
-            )
-            .unwrap();
-
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            let err = suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap_err();
-            assert_eq!(err, ContractError::AddressNotWhitelisted {});
-
-            suggest_counter_trade_helper(deps.as_mut(), "whitelist", 0).unwrap();
-
-            let err = remove_whitelisted_users(deps.as_mut(), 0, vec!["whitelist".to_string()])
-                .unwrap_err();
-            assert_eq!(
-                err,
-                ContractError::WrongTradeState {
-                    state: TradeState::Countered
-                }
-            );
-
-            let err =
-                add_whitelisted_users(deps.as_mut(), 0, vec!["whitelist".to_string()]).unwrap_err();
-            assert_eq!(
-                err,
-                ContractError::WrongTradeState {
-                    state: TradeState::Countered
-                }
-            );
-
-            create_private_trade_helper(deps.as_mut(), vec!["whitelist".to_string()]);
-
-            remove_whitelisted_users(deps.as_mut(), 1, vec!["whitelist".to_string()]).unwrap();
-            let info = TRADE_INFO.load(&deps.storage, 1_u64).unwrap();
-            let hash_set = HashSet::new();
-            assert_eq!(info.whitelisted_users, hash_set);
-
-            add_whitelisted_users(
-                deps.as_mut(),
-                1,
-                vec!["whitelist-1".to_string(), "whitelist".to_string()],
-            )
-            .unwrap();
-            add_whitelisted_users(
-                deps.as_mut(),
-                1,
-                vec!["whitelist-2".to_string(), "whitelist".to_string()],
-            )
-            .unwrap();
-            let info = TRADE_INFO.load(&deps.storage, 1_u64).unwrap();
-
-            let whitelisted_users = vec![
-                "whitelist".to_string(),
-                "whitelist-1".to_string(),
-                "whitelist-2".to_string(),
-            ];
-            let hash_set =
-                HashSet::from_iter(validate_addresses(&deps.api, &whitelisted_users).unwrap());
-            assert_eq!(info.whitelisted_users, hash_set);
-        }
-    }
-
-    fn suggest_counter_trade_helper(
-        deps: DepsMut,
-        counterer: &str,
-        trade_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(counterer, &[]);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::SuggestCounterTrade {
-                trade_id,
-                comment: Some("Q".to_string()),
-            },
-        )
-    }
-
-    fn add_asset_to_counter_trade_helper(
-        deps: DepsMut,
-        counterer: &str,
-        trade_id: u64,
-        counter_id: u64,
-        asset: AssetInfo,
-        coins_to_send: &[Coin],
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(counterer, coins_to_send);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::AddAsset {
-                action: AddAssetAction::ToCounterTrade {
-                    trade_id,
-                    counter_id,
-                },
-                asset,
-            },
-        )
-    }
-
-    fn confirm_counter_trade_helper(
-        deps: DepsMut,
-        sender: &str,
-        trade_id: u64,
-        counter_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(sender, &[]);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::ConfirmCounterTrade {
-                trade_id,
-                counter_id: Some(counter_id),
-            },
-        )
-    }
-
-    fn review_counter_trade_helper(
-        deps: DepsMut,
-        sender: &str,
-        trade_id: u64,
-        counter_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(sender, &[]);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::ReviewCounterTrade {
-                trade_id,
-                counter_id,
-                comment: Some("Shit NFT my girl".to_string()),
-            },
-        )
-    }
-
-    fn accept_trade_helper(
-        deps: DepsMut,
-        sender: &str,
-        trade_id: u64,
-        counter_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(sender, &[]);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::AcceptTrade {
-                trade_id,
-                counter_id,
-                comment: Some("You're very kind madam".to_string()),
-            },
-        )
-    }
-
-    fn cancel_trade_helper(
-        deps: DepsMut,
-        sender: &str,
-        trade_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(sender, &[]);
-        let env = mock_env();
-
-        execute(deps, env, info, ExecuteMsg::CancelTrade { trade_id })
-    }
-
-    fn cancel_counter_trade_helper(
-        deps: DepsMut,
-        sender: &str,
-        trade_id: u64,
-        counter_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(sender, &[]);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::CancelCounterTrade {
-                trade_id,
-                counter_id,
-            },
-        )
-    }
-
-    fn refuse_counter_trade_helper(
-        deps: DepsMut,
-        trader: &str,
-        trade_id: u64,
-        counter_id: u64,
-    ) -> Result<Response, ContractError> {
-        let info = mock_info(trader, &[]);
-        let env = mock_env();
-
-        execute(
-            deps,
-            env,
-            info,
-            ExecuteMsg::RefuseCounterTrade {
-                trade_id,
-                counter_id,
-            },
-        )
-    }
-
-    pub mod counter_trade_tests {
-        use super::*;
-        use crate::query::{AllTradesResponse, TradeResponse};
-        use cosmwasm_std::{coin, from_json, Api, SubMsg};
-        use p2p_trading_export::msg::{
-            AdditionalTradeInfoResponse, QueryFilters, TradeInfoResponse,
-        };
-        use p2p_trading_export::state::{Comment, CounterTradeInfo};
-
-        #[test]
-        fn create_counter_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-
-            let err = suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap_err();
-
-            assert_eq!(err, ContractError::NotCounterable {});
-
-            let err = suggest_counter_trade_helper(deps.as_mut(), "counterer", 1).unwrap_err();
-
-            assert_eq!(err, ContractError::NotFoundInTradeInfo {});
-
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            let res = suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "create_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-            // We need to make sure it is not couterable in case the counter is accepted
-        }
-        #[test]
-        fn create_counter_trade_and_add_funds() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            let res = add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Coin(coin(2, "token")),
-                &coins(2, "token"),
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "add_asset"),
-                    Attribute::new("asset_type", "fund"),
-                    Attribute::new("denom", "token"),
-                    Attribute::new("amount", "2"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
-            assert_eq!(counter_trade_info.state, TradeState::Created);
-            assert_eq!(
-                counter_trade_info.associated_assets,
-                vec![AssetInfo::Coin(coin(2, "token"))]
-            );
-        }
-
-        #[test]
-        fn create_counter_trade_and_add_cw20_tokens() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            let res = add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "add_asset"),
-                    Attribute::new("asset_type", "token"),
-                    Attribute::new("token", "token"),
-                    Attribute::new("amount", "100"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            let err = add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                1,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
-
-            // Verifying the state has been changed
-            let trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(trade_info.state, TradeState::Countered);
-            assert_eq!(trade_info.associated_assets, vec![]);
-
-            let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
-            assert_eq!(counter_trade_info.state, TradeState::Created);
-            assert_eq!(
-                counter_trade_info.associated_assets,
-                vec![AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::from(100u64)
-                }),]
-            );
-
-            // This triggers an error, the creator is not the same as the sender
-            let err = add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "bad_person",
-                0,
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::CounterTraderNotCreator {});
-        }
-
-        #[test]
-        fn create_trade_and_add_cw721_tokens() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            let res = add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "add_asset"),
-                    Attribute::new("asset_type", "NFT"),
-                    Attribute::new("nft", "nft"),
-                    Attribute::new("token_id", "58"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            // Verifying the state has been changed
-            let trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(trade_info.state, TradeState::Countered);
-            assert_eq!(trade_info.associated_assets, vec![]);
-
-            let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
-            assert_eq!(counter_trade_info.state, TradeState::Created);
-            assert_eq!(
-                counter_trade_info.associated_assets,
-                vec![AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string()
-                }),]
-            );
-
-            // This triggers an error, the counter-trade creator is not the same as the sender
-            let err = add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "bad_person",
-                0,
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "token".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::CounterTraderNotCreator {});
-        }
-
-        #[test]
-        fn create_counter_trade_automatic_trade_id() {
-            let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
-            let env = mock_env();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "creator", 1).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            execute(
-                deps.as_mut(),
-                env.clone(),
-                info,
-                ExecuteMsg::AddAsset {
-                    action: AddAssetAction::ToLastCounterTrade { trade_id: 0 },
-                    asset: AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "cw20".to_string(),
-                        amount: Uint128::from(100u64),
-                    }),
-                },
-            )
-            .unwrap();
-
-            let info = mock_info("creator", &coins(97u128, "uluna"));
-            execute(
-                deps.as_mut(),
-                env,
-                info,
-                ExecuteMsg::AddAsset {
-                    action: AddAssetAction::ToLastCounterTrade { trade_id: 0 },
-                    asset: AssetInfo::Coin(coin(97u128, "uluna")),
-                },
-            )
-            .unwrap();
-
-            let info = mock_info("creator", &[]);
-            let env = mock_env();
-
-            execute(
-                deps.as_mut(),
-                env,
-                info,
-                ExecuteMsg::ConfirmCounterTrade {
-                    trade_id: 0,
-                    counter_id: None,
-                },
-            )
-            .unwrap();
-
-            let trade_info = COUNTER_TRADE_INFO
-                .load(&deps.storage, (0u64, 0u64))
-                .unwrap();
-            assert_eq!(
-                trade_info.associated_assets,
-                vec![
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "cw20".to_string(),
-                        amount: Uint128::from(100u128)
-                    }),
-                    AssetInfo::Coin(coin(97, "uluna"))
-                ]
-            );
-            assert_eq!(trade_info.state, TradeState::Published);
-        }
-
-        #[test]
-        fn create_counter_trade_add_remove_tokens() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft-2".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Coin(coin(100, "luna")),
-                &coins(100, "luna"),
-            )
-            .unwrap();
-
-            let res = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![
-                    (
-                        0,
-                        AssetInfo::Cw721Coin(Cw721Coin {
-                            address: "nft".to_string(),
-                            token_id: "58".to_string(),
-                        }),
-                    ),
-                    (
-                        2,
-                        AssetInfo::Cw20Coin(Cw20Coin {
-                            address: "token".to_string(),
-                            amount: Uint128::from(58u64),
-                        }),
-                    ),
-                    (3, AssetInfo::Coin(coin(58, "luna"))),
-                ],
-            )
-            .unwrap();
-
-            assert_eq!(res.attributes.len(), 14);
-            assert_eq!(
-                res.messages,
-                vec![
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw721ExecuteMsg::TransferNft {
-                                recipient: "counterer".to_string(),
-                                token_id: "58".to_string()
-                            },
-                            "nft"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(
-                        into_cosmos_msg(
-                            Cw20ExecuteMsg::Transfer {
-                                recipient: "counterer".to_string(),
-                                amount: Uint128::from(58u64)
-                            },
-                            "token"
-                        )
-                        .unwrap()
-                    ),
-                    SubMsg::new(BankMsg::Send {
-                        to_address: "counterer".to_string(),
-                        amount: coins(58, "luna"),
-                    })
-                ]
-            );
-
-            let new_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        token_id: "58".to_string(),
-                        address: "nft-2".to_string()
-                    }),
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        amount: Uint128::from(42u64),
-                        address: "token".to_string()
-                    }),
-                    AssetInfo::Coin(coin(42, "luna"))
-                ],
-            );
-
-            remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![
-                    (
-                        1,
-                        AssetInfo::Cw20Coin(Cw20Coin {
-                            address: "token".to_string(),
-                            amount: Uint128::from(42u64),
-                        }),
-                    ),
-                    (2, AssetInfo::Coin(coin(42, "luna"))),
-                ],
-            )
-            .unwrap();
-
-            let new_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
-            assert_eq!(
-                new_trade_info.associated_assets,
-                vec![AssetInfo::Cw721Coin(Cw721Coin {
-                    token_id: "58".to_string(),
-                    address: "nft-2".to_string()
-                }),],
-            );
-
-            // This triggers an error, the counterer is not the same as the sender
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "bad_person",
-                0,
-                Some(0),
-                vec![(
-                    0,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-2".to_string(),
-                        token_id: "58".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::CounterTraderNotCreator {});
-
-            // This triggers an error, no matching funds were found
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![(
-                    1,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-2".to_string(),
-                        token_id: "58".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 1 });
-
-            // This triggers an error, no matching funds were found
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![(
-                    0,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-1".to_string(),
-                        token_id: "58".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 0 });
-
-            // This triggers an error, no matching funds were found
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![(
-                    0,
-                    AssetInfo::Cw721Coin(Cw721Coin {
-                        address: "nft-2".to_string(),
-                        token_id: "42".to_string(),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 0 });
-        }
-
-        #[test]
-        fn create_trade_add_remove_tokens_errors() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft-2".to_string(),
-                    token_id: "58".to_string(),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Cw20Coin(Cw20Coin {
-                    address: "token".to_string(),
-                    amount: Uint128::new(100u128),
-                }),
-                &[],
-            )
-            .unwrap();
-
-            add_asset_to_counter_trade_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                0,
-                AssetInfo::Coin(coin(100, "luna")),
-                &coins(100, "luna"),
-            )
-            .unwrap();
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![(
-                    2,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "token".to_string(),
-                        amount: Uint128::from(101u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(
-                err,
-                ContractError::TooMuchWithdrawn {
-                    address: "token".to_string(),
-                    wanted: 101,
-                    available: 100
-                }
-            );
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![(
-                    0,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "token".to_string(),
-                        amount: Uint128::from(101u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 0 });
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![(
-                    2,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "wrong-token".to_string(),
-                        amount: Uint128::from(101u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::AssetNotFound { position: 2 });
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-
-            let err = remove_assets_helper(
-                deps.as_mut(),
-                "counterer",
-                0,
-                Some(0),
-                vec![(
-                    2,
-                    AssetInfo::Cw20Coin(Cw20Coin {
-                        address: "token".to_string(),
-                        amount: Uint128::from(58u64),
-                    }),
-                )],
-            )
-            .unwrap_err();
-
-            assert_eq!(err, ContractError::CounterTradeAlreadyPublished {});
-        }
-
-        #[test]
-        fn confirm_counter_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            //Wrong trade id
-            let err = confirm_counter_trade_helper(deps.as_mut(), "creator", 1, 0).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
-
-            //Wrong counter id
-            let err = confirm_counter_trade_helper(deps.as_mut(), "creator", 0, 1).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
-
-            //Wrong trader
-            let err = confirm_counter_trade_helper(deps.as_mut(), "bad_person", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::CounterTraderNotCreator {});
-
-            // This time, it has to work fine
-            let res = confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "confirm_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            //Already confirmed
-            let err = confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap_err();
-            assert_eq!(
-                err,
-                ContractError::CantChangeCounterTradeState {
-                    from: TradeState::Published,
-                    to: TradeState::Published
-                }
-            );
-        }
-
-        #[test]
-        fn review_counter_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            //Wrong trade id
-            let err = review_counter_trade_helper(deps.as_mut(), "creator", 1, 0).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInTradeInfo {});
-
-            //Wrong counter id
-            let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 1).unwrap_err();
-            assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
-
-            //Wrong trader
-            let err = review_counter_trade_helper(deps.as_mut(), "bad_person", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::TraderNotCreator {});
-
-            let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
-            assert_eq!(
-                err,
-                ContractError::CantChangeCounterTradeState {
-                    from: TradeState::Created,
-                    to: TradeState::Created
-                }
-            );
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-
-            // This time, it has to work fine
-            let res = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "review_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            // Because this was the only counter
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(new_trade_info.state, TradeState::Countered {});
-        }
-
-        #[test]
-        fn review_counter_trade_when_accepted() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-
-            let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeAlreadyAccepted {});
-        }
-
-        #[test]
-        fn review_counter_trade_when_cancelled() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeCancelled {});
-        }
-
-        #[test]
-        fn review_counter_with_multiple() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            // We suggest and confirm one more counter
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 1).unwrap();
-
-            // This time, it has to work fine
-            let res = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "review_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-
-            let new_trade_info = load_trade(&deps.storage, 0).unwrap();
-            assert_eq!(new_trade_info.state, TradeState::Countered {});
-        }
-
-        #[test]
-        fn refuse_counter_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            let res = refuse_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "refuse_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-        }
-
-        #[test]
-        fn cancel_counter_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            cancel_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-
-            let err = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
-
-            assert_eq!(err, ContractError::CantAcceptNotPublishedCounter {});
-        }
-
-        #[test]
-        fn refuse_counter_trade_with_multiple() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            // We suggest and confirm one more counter
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            // We suggest one more counter
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            let res = refuse_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-            assert_eq!(
-                res.attributes,
-                vec![
-                    Attribute::new("action", "refuse_counter_trade"),
-                    Attribute::new("trade_id", "0"),
-                    Attribute::new("counter_id", "0"),
-                    Attribute::new("trader", "creator"),
-                    Attribute::new("counter_trader", "counterer"),
-                ]
-            );
-        }
-
-        #[test]
-        fn refuse_accepted_counter_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-            let err = refuse_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
-            assert_eq!(err, ContractError::TradeAlreadyAccepted {});
-        }
-
-        #[test]
-        fn cancel_accepted_counter_trade() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-            let err = cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
-            assert_eq!(
-                err,
-                ContractError::CantChangeTradeState {
-                    from: TradeState::Accepted,
-                    to: TradeState::Cancelled
-                }
-            );
-        }
-
-        #[test]
-        fn confirm_counter_trade_after_accepted() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-
-            //Already confirmed
-            let err = confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap_err();
-            assert_eq!(
-                err,
-                ContractError::CantChangeCounterTradeState {
-                    from: TradeState::Accepted,
-                    to: TradeState::Published
-                }
-            );
-        }
-
-        #[test]
-        fn query_trades_by_counterer() {
-            let mut deps = mock_dependencies();
-            init_helper(deps.as_mut());
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
-
-            // When no counter_trades
-            let env = mock_env();
-            let res: AllTradesResponse = from_json(
-                query(
-                    deps.as_ref(),
-                    env,
-                    QueryMsg::GetAllTrades {
-                        start_after: None,
-                        limit: None,
-                        filters: Some(QueryFilters {
-                            counterer: Some("counterer".to_string()),
-                            ..QueryFilters::default()
-                        }),
-                    },
-                )
-                .unwrap(),
-            )
-            .unwrap();
-
-            assert_eq!(res.trades, vec![]);
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
-            confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
-            accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
-
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap();
-            create_trade_helper(deps.as_mut(), "creator");
-            confirm_trade_helper(deps.as_mut(), "creator", 2).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-            suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
-
-            suggest_counter_trade_helper(deps.as_mut(), "counterer", 2).unwrap();
-
-            let env = mock_env();
-            let res: AllTradesResponse = from_json(
-                query(
-                    deps.as_ref(),
-                    env,
-                    QueryMsg::GetAllTrades {
-                        start_after: None,
-                        limit: None,
-                        filters: Some(QueryFilters {
-                            counterer: Some("counterer".to_string()),
-                            ..QueryFilters::default()
-                        }),
-                    },
-                )
-                .unwrap(),
-            )
-            .unwrap();
-
-            let env = mock_env();
-            assert_eq!(
-                res.trades,
-                vec![
-                    {
-                        TradeResponse {
-                            trade_id: 2,
-                            counter_id: None,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("creator").unwrap(),
-                                last_counter_id: Some(0),
-                                state: TradeState::Countered,
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: env.block.time,
-                                    }),
-                                    time: env.block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    },
-                    {
-                        TradeResponse {
-                            trade_id: 0,
-                            counter_id: None,
-                            trade_info: Some(TradeInfoResponse {
-                                owner: deps.api.addr_validate("creator").unwrap(),
-                                last_counter_id: Some(3),
-                                state: TradeState::Accepted,
-                                accepted_info: Some(CounterTradeInfo {
-                                    trade_id: 0,
-                                    counter_id: 0,
-                                }),
-                                additional_info: AdditionalTradeInfoResponse {
-                                    owner_comment: Some(Comment {
-                                        comment: "Q".to_string(),
-                                        time: env.block.time,
-                                    }),
-                                    time: env.block.time,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            }),
-                        }
-                    }
-                ]
-            );
-        }
-    }
-
-    #[test]
-    fn create_trade_preview() {
-        let mut deps = mock_dependencies();
-        init_helper(deps.as_mut());
-
-        create_trade_helper(deps.as_mut(), "creator");
-
-        add_asset_to_trade_helper(
-            deps.as_mut(),
-            "creator",
-            0,
-            AssetInfo::Cw721Coin(Cw721Coin {
-                address: "nft".to_string(),
-                token_id: "58".to_string(),
-            }),
-            &[],
-        )
-        .unwrap();
-
-        add_asset_to_trade_helper(
-            deps.as_mut(),
-            "creator",
-            0,
-            AssetInfo::Cw721Coin(Cw721Coin {
-                address: "nft".to_string(),
-                token_id: "59".to_string(),
-            }),
-            &[],
-        )
-        .unwrap();
-
-        execute(
-            deps.as_mut(),
-            mock_env(),
-            mock_info("creator", &[]),
-            ExecuteMsg::SetTradePreview {
-                action: AddAssetAction::ToTrade { trade_id: 0 },
-                asset: AssetInfo::Cw721Coin(Cw721Coin {
-                    address: "nft".to_string(),
-                    token_id: "59".to_string(),
-                }),
-            },
-        )
-        .unwrap();
-    }
+    // pub mod trade_tests {
+    //     use super::*;
+    //     use crate::query::{query_counter_trades, TradeResponse};
+    //     use crate::trade::validate_addresses;
+    //     use cosmwasm_std::{coin, Api, SubMsg};
+    //     use p2p_trading_export::msg::{
+    //         AdditionalTradeInfoResponse, QueryFilters, TradeInfoResponse,
+    //     };
+    //     use p2p_trading_export::state::{Comment, CounterTradeInfo};
+    //     use std::collections::HashSet;
+    //     use std::iter::FromIterator;
+    //     use utils::state::Cw721Coin;
+
+    //     #[test]
+    //     fn create_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         let res = create_trade_helper(deps.as_mut(), "creator");
+
+    //         assert_eq!(res.messages, vec![]);
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "create_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //             ]
+    //         );
+
+    //         let res = create_trade_helper(deps.as_mut(), "creator");
+
+    //         assert_eq!(res.messages, vec![]);
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "create_trade"),
+    //                 Attribute::new("trade_id", "1"),
+    //                 Attribute::new("trader", "creator"),
+    //             ]
+    //         );
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+
+    //         assert_eq!(new_trade_info.state, TradeState::Created {});
+
+    //         // Query all and check that trades exist, without filters specified
+    //         let res = query_all_trades(deps.as_ref(), None, None, None).unwrap();
+
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![
+    //                 {
+    //                     TradeResponse {
+    //                         trade_id: 1,
+    //                         counter_id: None,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("creator").unwrap(),
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: mock_env().block.time,
+    //                                 }),
+    //                                 time: mock_env().block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 },
+    //                 {
+    //                     TradeResponse {
+    //                         trade_id: 0,
+    //                         counter_id: None,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("creator").unwrap(),
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: mock_env().block.time,
+    //                                 }),
+    //                                 time: mock_env().block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 }
+    //             ]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn create_trade_and_nfts_wanted() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         let res = add_nfts_wanted_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             vec!["nft1".to_string(), "nft2".to_string()],
+    //         )
+    //         .unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "modify_parameter"),
+    //                 Attribute::new("name", "nfts_wanted"),
+    //                 Attribute::new("operation_type", "add"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("trader", "creator")
+    //             ]
+    //         );
+
+    //         let trade = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(
+    //             trade.additional_info.nfts_wanted,
+    //             HashSet::from_iter(vec![Addr::unchecked("nft1"), Addr::unchecked("nft2")])
+    //         );
+
+    //         add_nfts_wanted_helper(deps.as_mut(), "creator", 0, vec!["nft1".to_string()]).unwrap();
+    //         remove_nfts_wanted_helper(deps.as_mut(), "creator", 0, vec!["nft1".to_string()])
+    //             .unwrap();
+
+    //         let trade = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(
+    //             trade.additional_info.nfts_wanted,
+    //             HashSet::from_iter(vec![Addr::unchecked("nft2")])
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn create_multiple_trades_and_query() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         let res = create_trade_helper(deps.as_mut(), "creator");
+
+    //         assert_eq!(res.messages, vec![]);
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "create_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //             ]
+    //         );
+
+    //         let res = create_trade_helper(deps.as_mut(), "creator2");
+
+    //         assert_eq!(res.messages, vec![]);
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "create_trade"),
+    //                 Attribute::new("trade_id", "1"),
+    //                 Attribute::new("trader", "creator2"),
+    //             ]
+    //         );
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+
+    //         assert_eq!(new_trade_info.state, TradeState::Created {});
+
+    //         let new_trade_info = load_trade(&deps.storage, 1).unwrap();
+    //         assert_eq!(new_trade_info.state, TradeState::Created {});
+
+    //         create_trade_helper(deps.as_mut(), "creator2");
+    //         confirm_trade_helper(deps.as_mut(), "creator2", 2).unwrap();
+
+    //         // Query all created trades check that creators are different
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Created.to_string()]),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![
+    //                 {
+    //                     TradeResponse {
+    //                         trade_id: 1,
+    //                         counter_id: None,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("creator2").unwrap(),
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: mock_env().block.time,
+    //                                 }),
+    //                                 time: mock_env().block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 },
+    //                 {
+    //                     TradeResponse {
+    //                         trade_id: 0,
+    //                         counter_id: None,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("creator").unwrap(),
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: mock_env().block.time,
+    //                                 }),
+    //                                 time: mock_env().block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 }
+    //             ]
+    //         );
+
+    //         // Verify that pagination by trade_id works
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             Some(1),
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Created.to_string()]),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     trade_id: 0,
+    //                     counter_id: None,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("creator").unwrap(),
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+
+    //         // Query that query returned only queries that are in created state and belong to creator2
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Created.to_string()]),
+    //                 owner: Some("creator2".to_string()),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![TradeResponse {
+    //                 trade_id: 1,
+    //                 counter_id: None,
+    //                 trade_info: Some(TradeInfoResponse {
+    //                     owner: deps.api.addr_validate("creator2").unwrap(),
+    //                     additional_info: AdditionalTradeInfoResponse {
+    //                         owner_comment: Some(Comment {
+    //                             comment: "Q".to_string(),
+    //                             time: mock_env().block.time
+    //                         }),
+    //                         time: mock_env().block.time,
+    //                         ..Default::default()
+    //                     },
+    //                     ..Default::default()
+    //                 })
+    //             }]
+    //         );
+
+    //         // Check that if states are None that owner query still works
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 owner: Some("creator2".to_string()),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![
+    //                 TradeResponse {
+    //                     trade_id: 2,
+    //                     counter_id: None,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("creator2").unwrap(),
+    //                         state: TradeState::Published,
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     })
+    //                 },
+    //                 TradeResponse {
+    //                     trade_id: 1,
+    //                     counter_id: None,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("creator2").unwrap(),
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     })
+    //                 }
+    //             ]
+    //         );
+
+    //         // Check that queries with published state do not return anything. Because none exists.
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Accepted.to_string()]),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(res.trades, vec![]);
+
+    //         // Check that queries with published state do not return anything when owner is specified. Because none exists.
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Accepted.to_string()]),
+    //                 owner: Some("creator2".to_string()),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+    //         assert_eq!(res.trades, vec![]);
+    //     }
+
+    //     #[test]
+    //     fn create_trade_and_add_funds() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         let res = add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(2, "token")),
+    //             &coins(2, "token"),
+    //         )
+    //         .unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "add_asset"),
+    //                 Attribute::new("asset_type", "fund"),
+    //                 Attribute::new("denom", "token"),
+    //                 Attribute::new("amount", "2"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //             ]
+    //         );
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(2, "token")),
+    //             &coins(2, "token"),
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(2, "other_token")),
+    //             &coins(2, "other_token"),
+    //         )
+    //         .unwrap();
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(
+    //             new_trade_info.associated_assets,
+    //             vec![
+    //                 AssetInfo::Coin(Coin {
+    //                     amount: Uint128::from(4u64),
+    //                     denom: "token".to_string()
+    //                 }),
+    //                 AssetInfo::Coin(Coin {
+    //                     amount: Uint128::from(2u64),
+    //                     denom: "other_token".to_string()
+    //                 })
+    //             ]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn create_trade_and_add_cw721_tokens() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         let res = add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "add_asset"),
+    //                 Attribute::new("asset_type", "NFT"),
+    //                 Attribute::new("nft", "nft"),
+    //                 Attribute::new("token_id", "58"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //             ]
+    //         );
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(
+    //             new_trade_info.associated_assets,
+    //             vec![AssetInfo::Cw721Coin(Cw721Coin {
+    //                 token_id: "58".to_string(),
+    //                 address: "nft".to_string()
+    //             })]
+    //         );
+
+    //         // This triggers an error, the creator is not the same as the sender
+    //         let err = add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "bad_person",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "other_token".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::TraderNotCreator {});
+    //     }
+
+    //     #[test]
+    //     fn create_trade_and_withdraw() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "1155".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "other_token".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         withdraw_cancelled_trade_helper(deps.as_mut(), "bas_person", 0).unwrap_err();
+    //         withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(new_trade_info.state, TradeState::Cancelled);
+
+    //         withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
+    //     }
+    //     #[test]
+    //     fn create_trade_automatic_trade_id() {
+    //         let mut deps = mock_dependencies();
+    //         let info = mock_info("creator", &[]);
+    //         let env = mock_env();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         execute(
+    //             deps.as_mut(),
+    //             env.clone(),
+    //             info,
+    //             ExecuteMsg::AddAsset {
+    //                 action: AddAssetAction::ToLastTrade {},
+    //                 asset: AssetInfo::Coin(Coin {
+    //                     denom: "cw20".to_string(),
+    //                     amount: Uint128::from(100u64),
+    //                 }),
+    //             },
+    //         )
+    //         .unwrap();
+
+    //         let info = mock_info("creator", &coins(97u128, "uluna"));
+    //         execute(
+    //             deps.as_mut(),
+    //             env,
+    //             info,
+    //             ExecuteMsg::AddAsset {
+    //                 action: AddAssetAction::ToLastTrade {},
+    //                 asset: AssetInfo::Coin(coin(97u128, "uluna")),
+    //             },
+    //         )
+    //         .unwrap();
+
+    //         let trade_info = TRADE_INFO.load(&deps.storage, 1u64).unwrap();
+    //         assert_eq!(
+    //             trade_info.associated_assets,
+    //             vec![AssetInfo::Coin(coin(97u128, "uluna")),]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn create_trade_add_remove_tokens() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft-2".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(100, "luna")),
+    //             &coins(100, "luna"),
+    //         )
+    //         .unwrap();
+
+    //         let res = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![
+    //                 (
+    //                     0,
+    //                     AssetInfo::Cw721Coin(Cw721Coin {
+    //                         address: "nft".to_string(),
+    //                         token_id: "58".to_string(),
+    //                     }),
+    //                 ),
+    //                 (4, AssetInfo::Coin(coin(58, "luna"))),
+    //             ],
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.messages,
+    //             vec![
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw721ExecuteMsg::TransferNft {
+    //                             recipient: "creator".to_string(),
+    //                             token_id: "58".to_string()
+    //                         },
+    //                         "nft"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw1155ExecuteMsg::SendFrom {
+    //                             from: mock_env().contract.address.to_string(),
+    //                             to: "creator".to_string(),
+    //                             token_id: "58".to_string(),
+    //                             value: Uint128::from(58u128),
+    //                             msg: None
+    //                         },
+    //                         "cw1155token"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw20ExecuteMsg::Transfer {
+    //                             recipient: "creator".to_string(),
+    //                             amount: Uint128::from(58u64)
+    //                         },
+    //                         "token"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(BankMsg::Send {
+    //                     to_address: "creator".to_string(),
+    //                     amount: coins(58, "luna"),
+    //                 })
+    //             ]
+    //         );
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(
+    //             new_trade_info.associated_assets,
+    //             vec![
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     token_id: "58".to_string(),
+    //                     address: "nft-2".to_string()
+    //                 }),
+    //                 AssetInfo::Cw1155Coin(Cw1155Coin {
+    //                     value: Uint128::from(42u64),
+    //                     address: "cw1155token".to_string(),
+    //                     token_id: "58".to_string()
+    //                 }),
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     amount: Uint128::from(42u64),
+    //                     address: "token".to_string()
+    //                 }),
+    //                 AssetInfo::Coin(coin(42, "luna"))
+    //             ],
+    //         );
+
+    //         remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![
+    //                 (
+    //                     1,
+    //                     AssetInfo::Cw1155Coin(Cw1155Coin {
+    //                         address: "cw1155token".to_string(),
+    //                         token_id: "58".to_string(),
+    //                         value: Uint128::from(42u64),
+    //                     }),
+    //                 ),
+    //                 (
+    //                     2,
+    //                     AssetInfo::Cw20Coin(Cw20Coin {
+    //                         address: "token".to_string(),
+    //                         amount: Uint128::from(42u64),
+    //                     }),
+    //                 ),
+    //                 (3, AssetInfo::Coin(coin(42, "luna"))),
+    //             ],
+    //         )
+    //         .unwrap();
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(
+    //             new_trade_info.associated_assets,
+    //             vec![AssetInfo::Cw721Coin(Cw721Coin {
+    //                 token_id: "58".to_string(),
+    //                 address: "nft-2".to_string()
+    //             }),],
+    //         );
+
+    //         // This triggers an error, the creator is not the same as the sender
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "bad_person",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-2".to_string(),
+    //                     token_id: "58".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::TraderNotCreator {});
+
+    //         // This triggers an error, no matching funds were found
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 1,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-2".to_string(),
+    //                     token_id: "58".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 1 });
+
+    //         // This triggers an error, no matching funds were found
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-1".to_string(),
+    //                     token_id: "58".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 0 });
+
+    //         // This triggers an error, no matching funds were found
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-2".to_string(),
+    //                     token_id: "42".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 0 });
+    //     }
+
+    //     #[test]
+    //     fn create_trade_add_remove_tokens_errors() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft-2".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(100, "luna")),
+    //             &coins(100, "luna"),
+    //         )
+    //         .unwrap();
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 2,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "token".to_string(),
+    //                     amount: Uint128::from(101u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(
+    //             err,
+    //             ContractError::TooMuchWithdrawn {
+    //                 address: "token".to_string(),
+    //                 wanted: 101,
+    //                 available: 100
+    //             }
+    //         );
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "token".to_string(),
+    //                     amount: Uint128::from(101u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 0 });
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 2,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "wrong-token".to_string(),
+    //                     amount: Uint128::from(101u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 2 });
+
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             None,
+    //             vec![(
+    //                 2,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "token".to_string(),
+    //                     amount: Uint128::from(58u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::TradeAlreadyPublished {});
+    //     }
+
+    //     #[test]
+    //     fn confirm_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         //Wrong trade id
+    //         let err = confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInTradeInfo {});
+
+    //         //Wrong trader
+    //         let err = confirm_trade_helper(deps.as_mut(), "bad_person", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TraderNotCreator {});
+
+    //         let res = confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "confirm_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //             ]
+    //         );
+
+    //         // Check with query that trade is confirmed, in published state
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Published.to_string()]),
+    //                 owner: Some("creator".to_string()),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     trade_id: 0,
+    //                     counter_id: None,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("creator").unwrap(),
+    //                         state: TradeState::Published,
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(new_trade_info.state, TradeState::Published {});
+
+    //         //Already confirmed
+    //         let err = confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
+    //         assert_eq!(
+    //             err,
+    //             ContractError::CantChangeTradeState {
+    //                 from: TradeState::Published,
+    //                 to: TradeState::Published
+    //             }
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn confirm_trade_and_try_add_assets() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         // This triggers an error, we can't send funds to confirmed trade
+
+    //         let err = add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(2, "token")),
+    //             &coins(2, "token"),
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(
+    //             err,
+    //             ContractError::WrongTradeState {
+    //                 state: TradeState::Published
+    //             }
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn accept_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         let err = accept_trade_helper(deps.as_mut(), "creator", 0, 5).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
+
+    //         let err = accept_trade_helper(deps.as_mut(), "creator", 1, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInTradeInfo {});
+
+    //         let err = accept_trade_helper(deps.as_mut(), "bad_person", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TraderNotCreator {});
+
+    //         let err = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::CantAcceptNotPublishedCounter {});
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+
+    //         let res = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "accept_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         let trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(trade_info.state, TradeState::Accepted {});
+    //         assert_eq!(
+    //             trade_info.accepted_info.unwrap(),
+    //             CounterTradeInfo {
+    //                 trade_id: 0,
+    //                 counter_id: 0
+    //             }
+    //         );
+
+    //         let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
+    //         assert_eq!(counter_trade_info.state, TradeState::Accepted {});
+
+    //         // Check with query that trade is confirmed, in ack state
+    //         let res = query_all_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Accepted.to_string()]),
+    //                 owner: Some("creator".to_string()),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     trade_id: 0,
+    //                     counter_id: None,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("creator").unwrap(),
+    //                         state: TradeState::Accepted,
+    //                         last_counter_id: Some(0),
+    //                         accepted_info: Some(CounterTradeInfo {
+    //                             trade_id: 0,
+    //                             counter_id: 0,
+    //                         }),
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+
+    //         // Check with query by trade id that one counter is returned
+    //         let res = query_counter_trades(deps.as_ref(), 0, None, None, None).unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     counter_id: Some(0),
+    //                     trade_id: 0,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("counterer").unwrap(),
+    //                         state: TradeState::Accepted,
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             trader_comment: Some(Comment {
+    //                                 comment: "You're very kind madam".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+
+    //         let res = query_counter_trades(deps.as_ref(), 0, Some(0), None, None).unwrap();
+    //         assert_eq!(res.counter_trades, vec![]);
+
+    //         // Check with queries that only one counter is returned by query and in accepted state
+    //         let res = query_all_counter_trades(deps.as_ref(), None, None, None).unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     counter_id: Some(0),
+    //                     trade_id: 0,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("counterer").unwrap(),
+    //                         state: TradeState::Accepted,
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             trader_comment: Some(Comment {
+    //                                 comment: "You're very kind madam".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn accept_trade_with_multiple_counter() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 1).unwrap();
+
+    //         let res = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "accept_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         let trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(trade_info.state, TradeState::Accepted {});
+
+    //         let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
+    //         assert_eq!(counter_trade_info.state, TradeState::Accepted {});
+
+    //         let counter_trade_info = load_counter_trade(&deps.storage, 0, 1).unwrap();
+    //         assert_eq!(counter_trade_info.state, TradeState::Refused {});
+
+    //         // Check that the only Accepted and Published counters are the accepted counter
+    //         let res = query_all_counter_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![
+    //                     TradeState::Accepted.to_string(),
+    //                     TradeState::Published.to_string(),
+    //                 ]),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     counter_id: Some(0),
+    //                     trade_id: 0,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("counterer").unwrap(),
+    //                         state: TradeState::Accepted,
+
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             trader_comment: Some(Comment {
+    //                                 comment: "You're very kind madam".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+    //         // Check that the other counters is cancelled
+    //         let res = query_all_counter_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![TradeState::Refused.to_string()]),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![
+    //                 {
+    //                     TradeResponse {
+    //                         counter_id: Some(2),
+    //                         trade_id: 0,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("counterer").unwrap(),
+    //                             state: TradeState::Refused,
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: mock_env().block.time,
+    //                                 }),
+    //                                 time: mock_env().block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 },
+    //                 {
+    //                     TradeResponse {
+    //                         counter_id: Some(1),
+    //                         trade_id: 0,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("counterer").unwrap(),
+    //                             state: TradeState::Refused,
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: mock_env().block.time,
+    //                                 }),
+    //                                 time: mock_env().block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 },
+    //             ]
+    //         );
+
+    //         // Check that both Accepted and Published counter queries exist, paginate to skip last counter trade
+    //         let res = query_all_counter_trades(
+    //             deps.as_ref(),
+    //             Some(CounterTradeInfo {
+    //                 trade_id: 0,
+    //                 counter_id: 1,
+    //             }),
+    //             None,
+    //             Some(QueryFilters {
+    //                 states: Some(vec![
+    //                     TradeState::Accepted.to_string(),
+    //                     TradeState::Published.to_string(),
+    //                 ]),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     counter_id: Some(0),
+    //                     trade_id: 0,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("counterer").unwrap(),
+    //                         state: TradeState::Accepted,
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             trader_comment: Some(Comment {
+    //                                 comment: "You're very kind madam".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn cancel_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         let err = cancel_trade_helper(deps.as_mut(), "creator", 1).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInTradeInfo {});
+
+    //         let err = cancel_trade_helper(deps.as_mut(), "bad_person", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TraderNotCreator {});
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+
+    //         let res = cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "cancel_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //             ]
+    //         );
+
+    //         // Query all counter trades make sure counter trade is cancelled with the trade
+    //         let res = query_all_counter_trades(deps.as_ref(), None, None, None).unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![{
+    //                 TradeResponse {
+    //                     counter_id: Some(0),
+    //                     trade_id: 0,
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("counterer").unwrap(),
+    //                         state: TradeState::Cancelled,
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time,
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     }),
+    //                 }
+    //             }]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn queries_with_multiple_trades_and_counter_trades() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap();
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 2).unwrap();
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 3).unwrap();
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 4).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer2", 0).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 1).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 2).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 3).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 4).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer2", 4).unwrap();
+
+    //         // Query all before second one, should return the first one
+    //         let res = query_all_counter_trades(
+    //             deps.as_ref(),
+    //             Some(CounterTradeInfo {
+    //                 trade_id: 0,
+    //                 counter_id: 1,
+    //             }),
+    //             None,
+    //             Some(QueryFilters {
+    //                 owner: Some("counterer2".to_string()),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![TradeResponse {
+    //                 trade_id: 0,
+    //                 counter_id: Some(0),
+    //                 trade_info: Some(TradeInfoResponse {
+    //                     owner: deps.api.addr_validate("counterer2").unwrap(),
+    //                     state: TradeState::Created,
+    //                     additional_info: AdditionalTradeInfoResponse {
+    //                         owner_comment: Some(Comment {
+    //                             comment: "Q".to_string(),
+    //                             time: mock_env().block.time
+    //                         }),
+    //                         time: mock_env().block.time,
+    //                         ..Default::default()
+    //                     },
+    //                     ..Default::default()
+    //                 })
+    //             }]
+    //         );
+
+    //         // Query all before first one, should return empty array
+    //         let res = query_all_counter_trades(
+    //             deps.as_ref(),
+    //             Some(CounterTradeInfo {
+    //                 trade_id: 0,
+    //                 counter_id: 0,
+    //             }),
+    //             None,
+    //             None,
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(res.counter_trades, vec![]);
+
+    //         // Query for non existing user should return empty []
+    //         let res = query_all_counter_trades(
+    //             deps.as_ref(),
+    //             None,
+    //             None,
+    //             Some(QueryFilters {
+    //                 owner: Some("counterer5".to_string()),
+    //                 ..Default::default()
+    //             }),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(res.counter_trades, vec![]);
+
+    //         // Query by trade_id should return counter queries for trade id 4
+    //         let res = query_counter_trades(deps.as_ref(), 4, None, None, None).unwrap();
+
+    //         assert_eq!(
+    //             res.counter_trades,
+    //             vec![
+    //                 TradeResponse {
+    //                     trade_id: 4,
+    //                     counter_id: Some(1),
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("counterer2").unwrap(),
+    //                         state: TradeState::Created,
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     })
+    //                 },
+    //                 TradeResponse {
+    //                     trade_id: 4,
+    //                     counter_id: Some(0),
+    //                     trade_info: Some(TradeInfoResponse {
+    //                         owner: deps.api.addr_validate("counterer").unwrap(),
+    //                         additional_info: AdditionalTradeInfoResponse {
+    //                             owner_comment: Some(Comment {
+    //                                 comment: "Q".to_string(),
+    //                                 time: mock_env().block.time
+    //                             }),
+    //                             time: mock_env().block.time,
+    //                             ..Default::default()
+    //                         },
+    //                         ..Default::default()
+    //                     })
+    //                 }
+    //             ]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn withdraw_accepted_assets() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+    //         set_fee_contract_helper(deps.as_mut());
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw1155Coin(Cw1155Coin {
+    //                 address: "cw1155".to_string(),
+    //                 token_id: "58".to_string(),
+    //                 value: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(9, "other_token")),
+    //             &coins(9, "other_token"),
+    //         )
+    //         .unwrap();
+
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "other_counterer", 0).unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "other_counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "other_counter-nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "other_counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "other_counter-token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "other_counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Coin(coin(5, "lunas")),
+    //             &coins(5, "lunas"),
+    //         )
+    //         .unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             1,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "counter-nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             1,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "counter-token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             1,
+    //             AssetInfo::Coin(coin(2, "token")),
+    //             &coins(2, "token"),
+    //         )
+    //         .unwrap();
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 1).unwrap();
+
+    //         // Little test to start with (can't withdraw if the trade is not accepted)
+    //         let err = withdraw_helper(deps.as_mut(), "anyone", "fee_contract", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeNotAccepted {});
+
+    //         accept_trade_helper(deps.as_mut(), "creator", 0, 1).unwrap();
+
+    //         // Withdraw tests
+    //         let err = withdraw_helper(deps.as_mut(), "bad_person", "fee_contract", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::NotWithdrawableByYou {});
+
+    //         let err = withdraw_helper(deps.as_mut(), "creator", "bad_person", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::Unauthorized {});
+
+    //         let res = withdraw_helper(deps.as_mut(), "creator", "fee_contract", 0).unwrap();
+    //         assert_eq!(
+    //             res.messages,
+    //             vec![
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw721ExecuteMsg::TransferNft {
+    //                             recipient: "creator".to_string(),
+    //                             token_id: "58".to_string()
+    //                         },
+    //                         "counter-nft"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw20ExecuteMsg::Transfer {
+    //                             recipient: "creator".to_string(),
+    //                             amount: Uint128::from(100u64)
+    //                         },
+    //                         "counter-token"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(BankMsg::Send {
+    //                     to_address: "creator".to_string(),
+    //                     amount: coins(2, "token"),
+    //                 })
+    //             ]
+    //         );
+
+    //         let err = withdraw_helper(deps.as_mut(), "creator", "fee_contract", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
+
+    //         let res = withdraw_helper(deps.as_mut(), "counterer", "fee_contract", 0).unwrap();
+    //         assert_eq!(
+    //             res.messages,
+    //             vec![
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw721ExecuteMsg::TransferNft {
+    //                             recipient: "counterer".to_string(),
+    //                             token_id: "58".to_string()
+    //                         },
+    //                         "nft"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw1155ExecuteMsg::SendFrom {
+    //                             to: "counterer".to_string(),
+    //                             from: mock_env().contract.address.to_string(),
+    //                             token_id: "58".to_string(),
+    //                             value: Uint128::from(100u128),
+    //                             msg: None
+    //                         },
+    //                         "cw1155"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw20ExecuteMsg::Transfer {
+    //                             recipient: "counterer".to_string(),
+    //                             amount: Uint128::from(100u64)
+    //                         },
+    //                         "token"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(BankMsg::Send {
+    //                     to_address: "counterer".to_string(),
+    //                     amount: coins(9, "other_token"),
+    //                 }),
+    //             ]
+    //         );
+
+    //         let err = withdraw_helper(deps.as_mut(), "counterer", "fee_contract", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
+
+    //         let res =
+    //             withdraw_aborted_counter_helper(deps.as_mut(), "other_counterer", 0, 0).unwrap();
+    //         assert_eq!(
+    //             res.messages,
+    //             vec![
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw721ExecuteMsg::TransferNft {
+    //                             recipient: "other_counterer".to_string(),
+    //                             token_id: "58".to_string()
+    //                         },
+    //                         "other_counter-nft"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw20ExecuteMsg::Transfer {
+    //                             recipient: "other_counterer".to_string(),
+    //                             amount: Uint128::from(100u64)
+    //                         },
+    //                         "other_counter-token"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(BankMsg::Send {
+    //                     to_address: "other_counterer".to_string(),
+    //                     amount: coins(5, "lunas"),
+    //                 }),
+    //             ]
+    //         );
+
+    //         let err = withdraw_aborted_counter_helper(deps.as_mut(), "other_counterer", 0, 0)
+    //             .unwrap_err();
+    //         assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
+    //     }
+
+    //     #[test]
+    //     fn withdraw_cancelled_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(5, "lunas")),
+    //             &coins(5, "lunas"),
+    //         )
+    //         .unwrap();
+
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "other_counter-token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         let res = withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         assert_eq!(
+    //             res.messages,
+    //             vec![
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw721ExecuteMsg::TransferNft {
+    //                             recipient: "creator".to_string(),
+    //                             token_id: "58".to_string()
+    //                         },
+    //                         "nft"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw20ExecuteMsg::Transfer {
+    //                             recipient: "creator".to_string(),
+    //                             amount: Uint128::from(100u64)
+    //                         },
+    //                         "token"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(BankMsg::Send {
+    //                     to_address: "creator".to_string(),
+    //                     amount: coins(5, "lunas"),
+    //                 }),
+    //             ]
+    //         );
+
+    //         let err = withdraw_cancelled_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
+
+    //         let res = withdraw_aborted_counter_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         assert_eq!(
+    //             res.messages,
+    //             vec![SubMsg::new(
+    //                 into_cosmos_msg(
+    //                     Cw20ExecuteMsg::Transfer {
+    //                         recipient: "counterer".to_string(),
+    //                         amount: Uint128::from(100u64)
+    //                     },
+    //                     "other_counter-token"
+    //                 )
+    //                 .unwrap()
+    //             ),]
+    //         );
+
+    //         let err =
+    //             withdraw_aborted_counter_helper(deps.as_mut(), "counterer", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeAlreadyWithdrawn {});
+    //     }
+
+    //     #[test]
+    //     fn private() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+    //         create_private_trade_helper(deps.as_mut(), vec!["whitelist".to_string()]);
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_trade_helper(
+    //             deps.as_mut(),
+    //             "creator",
+    //             0,
+    //             AssetInfo::Coin(coin(5, "lunas")),
+    //             &coins(5, "lunas"),
+    //         )
+    //         .unwrap();
+
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         let err = suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap_err();
+    //         assert_eq!(err, ContractError::AddressNotWhitelisted {});
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "whitelist", 0).unwrap();
+
+    //         let err = remove_whitelisted_users(deps.as_mut(), 0, vec!["whitelist".to_string()])
+    //             .unwrap_err();
+    //         assert_eq!(
+    //             err,
+    //             ContractError::WrongTradeState {
+    //                 state: TradeState::Countered
+    //             }
+    //         );
+
+    //         let err =
+    //             add_whitelisted_users(deps.as_mut(), 0, vec!["whitelist".to_string()]).unwrap_err();
+    //         assert_eq!(
+    //             err,
+    //             ContractError::WrongTradeState {
+    //                 state: TradeState::Countered
+    //             }
+    //         );
+
+    //         create_private_trade_helper(deps.as_mut(), vec!["whitelist".to_string()]);
+
+    //         remove_whitelisted_users(deps.as_mut(), 1, vec!["whitelist".to_string()]).unwrap();
+    //         let info = TRADE_INFO.load(&deps.storage, 1_u64).unwrap();
+    //         let hash_set = HashSet::new();
+    //         assert_eq!(info.whitelisted_users, hash_set);
+
+    //         add_whitelisted_users(
+    //             deps.as_mut(),
+    //             1,
+    //             vec!["whitelist-1".to_string(), "whitelist".to_string()],
+    //         )
+    //         .unwrap();
+    //         add_whitelisted_users(
+    //             deps.as_mut(),
+    //             1,
+    //             vec!["whitelist-2".to_string(), "whitelist".to_string()],
+    //         )
+    //         .unwrap();
+    //         let info = TRADE_INFO.load(&deps.storage, 1_u64).unwrap();
+
+    //         let whitelisted_users = vec![
+    //             "whitelist".to_string(),
+    //             "whitelist-1".to_string(),
+    //             "whitelist-2".to_string(),
+    //         ];
+    //         let hash_set =
+    //             HashSet::from_iter(validate_addresses(&deps.api, &whitelisted_users).unwrap());
+    //         assert_eq!(info.whitelisted_users, hash_set);
+    //     }
+    // }
+
+    // fn suggest_counter_trade_helper(
+    //     deps: DepsMut,
+    //     counterer: &str,
+    //     trade_id: u64,
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(counterer, &[]);
+    //     let env = mock_env();
+
+    //     execute(
+    //         deps,
+    //         env,
+    //         info,
+    //         ExecuteMsg::SuggestCounterTrade {
+    //             trade_id,
+    //             comment: Some("Q".to_string()),
+    //         },
+    //     )
+    // }
+
+    // fn add_asset_to_counter_trade_helper(
+    //     deps: DepsMut,
+    //     counterer: &str,
+    //     trade_id: u64,
+    //     counter_id: u64,
+    //     asset: AssetInfo,
+    //     coins_to_send: &[Coin],
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(counterer, coins_to_send);
+    //     let env = mock_env();
+
+    //     execute(
+    //         deps,
+    //         env,
+    //         info,
+    //         ExecuteMsg::AddAsset {
+    //             action: AddAssetAction::ToCounterTrade {
+    //                 trade_id,
+    //                 counter_id,
+    //             },
+    //             asset,
+    //         },
+    //     )
+    // }
+
+    // fn confirm_counter_trade_helper(
+    //     deps: DepsMut,
+    //     sender: &str,
+    //     trade_id: u64,
+    //     counter_id: u64,
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(sender, &[]);
+    //     let env = mock_env();
+
+    //     execute(
+    //         deps,
+    //         env,
+    //         info,
+    //         ExecuteMsg::ConfirmCounterTrade {
+    //             trade_id,
+    //             counter_id: Some(counter_id),
+    //         },
+    //     )
+    // }
+
+    // fn review_counter_trade_helper(
+    //     deps: DepsMut,
+    //     sender: &str,
+    //     trade_id: u64,
+    //     counter_id: u64,
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(sender, &[]);
+    //     let env = mock_env();
+
+    //     execute(
+    //         deps,
+    //         env,
+    //         info,
+    //         ExecuteMsg::ReviewCounterTrade {
+    //             trade_id,
+    //             counter_id,
+    //             comment: Some("Shit NFT my girl".to_string()),
+    //         },
+    //     )
+    // }
+
+    // fn accept_trade_helper(
+    //     deps: DepsMut,
+    //     sender: &str,
+    //     trade_id: u64,
+    //     counter_id: u64,
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(sender, &[]);
+    //     let env = mock_env();
+
+    //     execute(
+    //         deps,
+    //         env,
+    //         info,
+    //         ExecuteMsg::AcceptTrade {
+    //             trade_id,
+    //             counter_id,
+    //             comment: Some("You're very kind madam".to_string()),
+    //         },
+    //     )
+    // }
+
+    // fn cancel_trade_helper(
+    //     deps: DepsMut,
+    //     sender: &str,
+    //     trade_id: u64,
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(sender, &[]);
+    //     let env = mock_env();
+
+    //     execute(deps, env, info, ExecuteMsg::CancelTrade { trade_id })
+    // }
+
+    // fn cancel_counter_trade_helper(
+    //     deps: DepsMut,
+    //     sender: &str,
+    //     trade_id: u64,
+    //     counter_id: u64,
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(sender, &[]);
+    //     let env = mock_env();
+
+    //     execute(
+    //         deps,
+    //         env,
+    //         info,
+    //         ExecuteMsg::CancelCounterTrade {
+    //             trade_id,
+    //             counter_id,
+    //         },
+    //     )
+    // }
+
+    // fn refuse_counter_trade_helper(
+    //     deps: DepsMut,
+    //     trader: &str,
+    //     trade_id: u64,
+    //     counter_id: u64,
+    // ) -> Result<Response, ContractError> {
+    //     let info = mock_info(trader, &[]);
+    //     let env = mock_env();
+
+    //     execute(
+    //         deps,
+    //         env,
+    //         info,
+    //         ExecuteMsg::RefuseCounterTrade {
+    //             trade_id,
+    //             counter_id,
+    //         },
+    //     )
+    // }
+
+    // pub mod counter_trade_tests {
+    //     use super::*;
+    //     use crate::query::{AllTradesResponse, TradeResponse};
+    //     use cosmwasm_std::{coin, from_json, Api, SubMsg};
+    //     use p2p_trading_export::msg::{
+    //         AdditionalTradeInfoResponse, QueryFilters, TradeInfoResponse,
+    //     };
+    //     use p2p_trading_export::state::{Comment, CounterTradeInfo};
+
+    //     #[test]
+    //     fn create_counter_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+
+    //         let err = suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap_err();
+
+    //         assert_eq!(err, ContractError::NotCounterable {});
+
+    //         let err = suggest_counter_trade_helper(deps.as_mut(), "counterer", 1).unwrap_err();
+
+    //         assert_eq!(err, ContractError::NotFoundInTradeInfo {});
+
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         let res = suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "create_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+    //         // We need to make sure it is not couterable in case the counter is accepted
+    //     }
+    //     #[test]
+    //     fn create_counter_trade_and_add_funds() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         let res = add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Coin(coin(2, "token")),
+    //             &coins(2, "token"),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "add_asset"),
+    //                 Attribute::new("asset_type", "fund"),
+    //                 Attribute::new("denom", "token"),
+    //                 Attribute::new("amount", "2"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
+    //         assert_eq!(counter_trade_info.state, TradeState::Created);
+    //         assert_eq!(
+    //             counter_trade_info.associated_assets,
+    //             vec![AssetInfo::Coin(coin(2, "token"))]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn create_counter_trade_and_add_cw20_tokens() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         let res = add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "add_asset"),
+    //                 Attribute::new("asset_type", "token"),
+    //                 Attribute::new("token", "token"),
+    //                 Attribute::new("amount", "100"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         let err = add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             1,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
+
+    //         // Verifying the state has been changed
+    //         let trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(trade_info.state, TradeState::Countered);
+    //         assert_eq!(trade_info.associated_assets, vec![]);
+
+    //         let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
+    //         assert_eq!(counter_trade_info.state, TradeState::Created);
+    //         assert_eq!(
+    //             counter_trade_info.associated_assets,
+    //             vec![AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::from(100u64)
+    //             }),]
+    //         );
+
+    //         // This triggers an error, the creator is not the same as the sender
+    //         let err = add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "bad_person",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::CounterTraderNotCreator {});
+    //     }
+
+    //     #[test]
+    //     fn create_trade_and_add_cw721_tokens() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         let res = add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "add_asset"),
+    //                 Attribute::new("asset_type", "NFT"),
+    //                 Attribute::new("nft", "nft"),
+    //                 Attribute::new("token_id", "58"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         // Verifying the state has been changed
+    //         let trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(trade_info.state, TradeState::Countered);
+    //         assert_eq!(trade_info.associated_assets, vec![]);
+
+    //         let counter_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
+    //         assert_eq!(counter_trade_info.state, TradeState::Created);
+    //         assert_eq!(
+    //             counter_trade_info.associated_assets,
+    //             vec![AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string()
+    //             }),]
+    //         );
+
+    //         // This triggers an error, the counter-trade creator is not the same as the sender
+    //         let err = add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "bad_person",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "token".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::CounterTraderNotCreator {});
+    //     }
+
+    //     #[test]
+    //     fn create_counter_trade_automatic_trade_id() {
+    //         let mut deps = mock_dependencies();
+    //         let info = mock_info("creator", &[]);
+    //         let env = mock_env();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "creator", 1).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         execute(
+    //             deps.as_mut(),
+    //             env.clone(),
+    //             info,
+    //             ExecuteMsg::AddAsset {
+    //                 action: AddAssetAction::ToLastCounterTrade { trade_id: 0 },
+    //                 asset: AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "cw20".to_string(),
+    //                     amount: Uint128::from(100u64),
+    //                 }),
+    //             },
+    //         )
+    //         .unwrap();
+
+    //         let info = mock_info("creator", &coins(97u128, "uluna"));
+    //         execute(
+    //             deps.as_mut(),
+    //             env,
+    //             info,
+    //             ExecuteMsg::AddAsset {
+    //                 action: AddAssetAction::ToLastCounterTrade { trade_id: 0 },
+    //                 asset: AssetInfo::Coin(coin(97u128, "uluna")),
+    //             },
+    //         )
+    //         .unwrap();
+
+    //         let info = mock_info("creator", &[]);
+    //         let env = mock_env();
+
+    //         execute(
+    //             deps.as_mut(),
+    //             env,
+    //             info,
+    //             ExecuteMsg::ConfirmCounterTrade {
+    //                 trade_id: 0,
+    //                 counter_id: None,
+    //             },
+    //         )
+    //         .unwrap();
+
+    //         let trade_info = COUNTER_TRADE_INFO
+    //             .load(&deps.storage, (0u64, 0u64))
+    //             .unwrap();
+    //         assert_eq!(
+    //             trade_info.associated_assets,
+    //             vec![
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "cw20".to_string(),
+    //                     amount: Uint128::from(100u128)
+    //                 }),
+    //                 AssetInfo::Coin(coin(97, "uluna"))
+    //             ]
+    //         );
+    //         assert_eq!(trade_info.state, TradeState::Published);
+    //     }
+
+    //     #[test]
+    //     fn create_counter_trade_add_remove_tokens() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft-2".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Coin(coin(100, "luna")),
+    //             &coins(100, "luna"),
+    //         )
+    //         .unwrap();
+
+    //         let res = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![
+    //                 (
+    //                     0,
+    //                     AssetInfo::Cw721Coin(Cw721Coin {
+    //                         address: "nft".to_string(),
+    //                         token_id: "58".to_string(),
+    //                     }),
+    //                 ),
+    //                 (
+    //                     2,
+    //                     AssetInfo::Cw20Coin(Cw20Coin {
+    //                         address: "token".to_string(),
+    //                         amount: Uint128::from(58u64),
+    //                     }),
+    //                 ),
+    //                 (3, AssetInfo::Coin(coin(58, "luna"))),
+    //             ],
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(res.attributes.len(), 14);
+    //         assert_eq!(
+    //             res.messages,
+    //             vec![
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw721ExecuteMsg::TransferNft {
+    //                             recipient: "counterer".to_string(),
+    //                             token_id: "58".to_string()
+    //                         },
+    //                         "nft"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(
+    //                     into_cosmos_msg(
+    //                         Cw20ExecuteMsg::Transfer {
+    //                             recipient: "counterer".to_string(),
+    //                             amount: Uint128::from(58u64)
+    //                         },
+    //                         "token"
+    //                     )
+    //                     .unwrap()
+    //                 ),
+    //                 SubMsg::new(BankMsg::Send {
+    //                     to_address: "counterer".to_string(),
+    //                     amount: coins(58, "luna"),
+    //                 })
+    //             ]
+    //         );
+
+    //         let new_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
+    //         assert_eq!(
+    //             new_trade_info.associated_assets,
+    //             vec![
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     token_id: "58".to_string(),
+    //                     address: "nft-2".to_string()
+    //                 }),
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     amount: Uint128::from(42u64),
+    //                     address: "token".to_string()
+    //                 }),
+    //                 AssetInfo::Coin(coin(42, "luna"))
+    //             ],
+    //         );
+
+    //         remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![
+    //                 (
+    //                     1,
+    //                     AssetInfo::Cw20Coin(Cw20Coin {
+    //                         address: "token".to_string(),
+    //                         amount: Uint128::from(42u64),
+    //                     }),
+    //                 ),
+    //                 (2, AssetInfo::Coin(coin(42, "luna"))),
+    //             ],
+    //         )
+    //         .unwrap();
+
+    //         let new_trade_info = load_counter_trade(&deps.storage, 0, 0).unwrap();
+    //         assert_eq!(
+    //             new_trade_info.associated_assets,
+    //             vec![AssetInfo::Cw721Coin(Cw721Coin {
+    //                 token_id: "58".to_string(),
+    //                 address: "nft-2".to_string()
+    //             }),],
+    //         );
+
+    //         // This triggers an error, the counterer is not the same as the sender
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "bad_person",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-2".to_string(),
+    //                     token_id: "58".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::CounterTraderNotCreator {});
+
+    //         // This triggers an error, no matching funds were found
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 1,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-2".to_string(),
+    //                     token_id: "58".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 1 });
+
+    //         // This triggers an error, no matching funds were found
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-1".to_string(),
+    //                     token_id: "58".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 0 });
+
+    //         // This triggers an error, no matching funds were found
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw721Coin(Cw721Coin {
+    //                     address: "nft-2".to_string(),
+    //                     token_id: "42".to_string(),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 0 });
+    //     }
+
+    //     #[test]
+    //     fn create_trade_add_remove_tokens_errors() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft-2".to_string(),
+    //                 token_id: "58".to_string(),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Cw20Coin(Cw20Coin {
+    //                 address: "token".to_string(),
+    //                 amount: Uint128::new(100u128),
+    //             }),
+    //             &[],
+    //         )
+    //         .unwrap();
+
+    //         add_asset_to_counter_trade_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             0,
+    //             AssetInfo::Coin(coin(100, "luna")),
+    //             &coins(100, "luna"),
+    //         )
+    //         .unwrap();
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 2,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "token".to_string(),
+    //                     amount: Uint128::from(101u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(
+    //             err,
+    //             ContractError::TooMuchWithdrawn {
+    //                 address: "token".to_string(),
+    //                 wanted: 101,
+    //                 available: 100
+    //             }
+    //         );
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 0,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "token".to_string(),
+    //                     amount: Uint128::from(101u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 0 });
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 2,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "wrong-token".to_string(),
+    //                     amount: Uint128::from(101u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::AssetNotFound { position: 2 });
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+
+    //         let err = remove_assets_helper(
+    //             deps.as_mut(),
+    //             "counterer",
+    //             0,
+    //             Some(0),
+    //             vec![(
+    //                 2,
+    //                 AssetInfo::Cw20Coin(Cw20Coin {
+    //                     address: "token".to_string(),
+    //                     amount: Uint128::from(58u64),
+    //                 }),
+    //             )],
+    //         )
+    //         .unwrap_err();
+
+    //         assert_eq!(err, ContractError::CounterTradeAlreadyPublished {});
+    //     }
+
+    //     #[test]
+    //     fn confirm_counter_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         //Wrong trade id
+    //         let err = confirm_counter_trade_helper(deps.as_mut(), "creator", 1, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
+
+    //         //Wrong counter id
+    //         let err = confirm_counter_trade_helper(deps.as_mut(), "creator", 0, 1).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
+
+    //         //Wrong trader
+    //         let err = confirm_counter_trade_helper(deps.as_mut(), "bad_person", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::CounterTraderNotCreator {});
+
+    //         // This time, it has to work fine
+    //         let res = confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "confirm_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         //Already confirmed
+    //         let err = confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap_err();
+    //         assert_eq!(
+    //             err,
+    //             ContractError::CantChangeCounterTradeState {
+    //                 from: TradeState::Published,
+    //                 to: TradeState::Published
+    //             }
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn review_counter_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         //Wrong trade id
+    //         let err = review_counter_trade_helper(deps.as_mut(), "creator", 1, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInTradeInfo {});
+
+    //         //Wrong counter id
+    //         let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 1).unwrap_err();
+    //         assert_eq!(err, ContractError::NotFoundInCounterTradeInfo {});
+
+    //         //Wrong trader
+    //         let err = review_counter_trade_helper(deps.as_mut(), "bad_person", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TraderNotCreator {});
+
+    //         let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
+    //         assert_eq!(
+    //             err,
+    //             ContractError::CantChangeCounterTradeState {
+    //                 from: TradeState::Created,
+    //                 to: TradeState::Created
+    //             }
+    //         );
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+
+    //         // This time, it has to work fine
+    //         let res = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "review_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         // Because this was the only counter
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(new_trade_info.state, TradeState::Countered {});
+    //     }
+
+    //     #[test]
+    //     fn review_counter_trade_when_accepted() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+
+    //         let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeAlreadyAccepted {});
+    //     }
+
+    //     #[test]
+    //     fn review_counter_trade_when_cancelled() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         let err = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeCancelled {});
+    //     }
+
+    //     #[test]
+    //     fn review_counter_with_multiple() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         // We suggest and confirm one more counter
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 1).unwrap();
+
+    //         // This time, it has to work fine
+    //         let res = review_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "review_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+
+    //         let new_trade_info = load_trade(&deps.storage, 0).unwrap();
+    //         assert_eq!(new_trade_info.state, TradeState::Countered {});
+    //     }
+
+    //     #[test]
+    //     fn refuse_counter_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         let res = refuse_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "refuse_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn cancel_counter_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         cancel_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+
+    //         let err = accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
+
+    //         assert_eq!(err, ContractError::CantAcceptNotPublishedCounter {});
+    //     }
+
+    //     #[test]
+    //     fn refuse_counter_trade_with_multiple() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         // We suggest and confirm one more counter
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         // We suggest one more counter
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         let res = refuse_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+    //         assert_eq!(
+    //             res.attributes,
+    //             vec![
+    //                 Attribute::new("action", "refuse_counter_trade"),
+    //                 Attribute::new("trade_id", "0"),
+    //                 Attribute::new("counter_id", "0"),
+    //                 Attribute::new("trader", "creator"),
+    //                 Attribute::new("counter_trader", "counterer"),
+    //             ]
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn refuse_accepted_counter_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+    //         let err = refuse_counter_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap_err();
+    //         assert_eq!(err, ContractError::TradeAlreadyAccepted {});
+    //     }
+
+    //     #[test]
+    //     fn cancel_accepted_counter_trade() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+    //         let err = cancel_trade_helper(deps.as_mut(), "creator", 0).unwrap_err();
+    //         assert_eq!(
+    //             err,
+    //             ContractError::CantChangeTradeState {
+    //                 from: TradeState::Accepted,
+    //                 to: TradeState::Cancelled
+    //             }
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn confirm_counter_trade_after_accepted() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+
+    //         //Already confirmed
+    //         let err = confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap_err();
+    //         assert_eq!(
+    //             err,
+    //             ContractError::CantChangeCounterTradeState {
+    //                 from: TradeState::Accepted,
+    //                 to: TradeState::Published
+    //             }
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn query_trades_by_counterer() {
+    //         let mut deps = mock_dependencies();
+    //         init_helper(deps.as_mut());
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 0).unwrap();
+
+    //         // When no counter_trades
+    //         let env = mock_env();
+    //         let res: AllTradesResponse = from_json(
+    //             query(
+    //                 deps.as_ref(),
+    //                 env,
+    //                 QueryMsg::GetAllTrades {
+    //                     start_after: None,
+    //                     limit: None,
+    //                     filters: Some(QueryFilters {
+    //                         counterer: Some("counterer".to_string()),
+    //                         ..QueryFilters::default()
+    //                     }),
+    //                 },
+    //             )
+    //             .unwrap(),
+    //         )
+    //         .unwrap();
+
+    //         assert_eq!(res.trades, vec![]);
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 0).unwrap();
+    //         confirm_counter_trade_helper(deps.as_mut(), "counterer", 0, 0).unwrap();
+    //         accept_trade_helper(deps.as_mut(), "creator", 0, 0).unwrap();
+
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 1).unwrap();
+    //         create_trade_helper(deps.as_mut(), "creator");
+    //         confirm_trade_helper(deps.as_mut(), "creator", 2).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+    //         suggest_counter_trade_helper(deps.as_mut(), "bad_person", 1).unwrap();
+
+    //         suggest_counter_trade_helper(deps.as_mut(), "counterer", 2).unwrap();
+
+    //         let env = mock_env();
+    //         let res: AllTradesResponse = from_json(
+    //             query(
+    //                 deps.as_ref(),
+    //                 env,
+    //                 QueryMsg::GetAllTrades {
+    //                     start_after: None,
+    //                     limit: None,
+    //                     filters: Some(QueryFilters {
+    //                         counterer: Some("counterer".to_string()),
+    //                         ..QueryFilters::default()
+    //                     }),
+    //                 },
+    //             )
+    //             .unwrap(),
+    //         )
+    //         .unwrap();
+
+    //         let env = mock_env();
+    //         assert_eq!(
+    //             res.trades,
+    //             vec![
+    //                 {
+    //                     TradeResponse {
+    //                         trade_id: 2,
+    //                         counter_id: None,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("creator").unwrap(),
+    //                             last_counter_id: Some(0),
+    //                             state: TradeState::Countered,
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: env.block.time,
+    //                                 }),
+    //                                 time: env.block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 },
+    //                 {
+    //                     TradeResponse {
+    //                         trade_id: 0,
+    //                         counter_id: None,
+    //                         trade_info: Some(TradeInfoResponse {
+    //                             owner: deps.api.addr_validate("creator").unwrap(),
+    //                             last_counter_id: Some(3),
+    //                             state: TradeState::Accepted,
+    //                             accepted_info: Some(CounterTradeInfo {
+    //                                 trade_id: 0,
+    //                                 counter_id: 0,
+    //                             }),
+    //                             additional_info: AdditionalTradeInfoResponse {
+    //                                 owner_comment: Some(Comment {
+    //                                     comment: "Q".to_string(),
+    //                                     time: env.block.time,
+    //                                 }),
+    //                                 time: env.block.time,
+    //                                 ..Default::default()
+    //                             },
+    //                             ..Default::default()
+    //                         }),
+    //                     }
+    //                 }
+    //             ]
+    //         );
+    //     }
+    // }
+
+    // #[test]
+    // fn create_trade_preview() {
+    //     let mut deps = mock_dependencies();
+    //     init_helper(deps.as_mut());
+
+    //     create_trade_helper(deps.as_mut(), "creator");
+
+    //     add_asset_to_trade_helper(
+    //         deps.as_mut(),
+    //         "creator",
+    //         0,
+    //         AssetInfo::Cw721Coin(Cw721Coin {
+    //             address: "nft".to_string(),
+    //             token_id: "58".to_string(),
+    //         }),
+    //         &[],
+    //     )
+    //     .unwrap();
+
+    //     add_asset_to_trade_helper(
+    //         deps.as_mut(),
+    //         "creator",
+    //         0,
+    //         AssetInfo::Cw721Coin(Cw721Coin {
+    //             address: "nft".to_string(),
+    //             token_id: "59".to_string(),
+    //         }),
+    //         &[],
+    //     )
+    //     .unwrap();
+
+    //     execute(
+    //         deps.as_mut(),
+    //         mock_env(),
+    //         mock_info("creator", &[]),
+    //         ExecuteMsg::SetTradePreview {
+    //             action: AddAssetAction::ToTrade { trade_id: 0 },
+    //             asset: AssetInfo::Cw721Coin(Cw721Coin {
+    //                 address: "nft".to_string(),
+    //                 token_id: "59".to_string(),
+    //             }),
+    //         },
+    //     )
+    //     .unwrap();
+    // }
 }

--- a/contracts/p2p-trading/src/interface.rs
+++ b/contracts/p2p-trading/src/interface.rs
@@ -1,0 +1,28 @@
+use cw_orch::{interface, prelude::*};
+use p2p_trading_export::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+
+pub const CONTRACT_ID: &str = "p2p_trading";
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg, id = CONTRACT_ID)]
+pub struct P2PTrading;
+
+impl<Chain> Uploadable for P2PTrading<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(_chain: &ChainInfoOwned) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path("p2p_trading")
+            .unwrap()
+    }
+
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper() -> Box<dyn MockContract<Empty>> {
+        Box::new(
+            ContractWrapper::new_with_empty(
+                crate::contract::execute,
+                crate::contract::instantiate,
+                crate::contract::query,
+            )
+            .with_migrate(crate::contract::migrate),
+        )
+    }
+}

--- a/contracts/p2p-trading/src/lib.rs
+++ b/contracts/p2p-trading/src/lib.rs
@@ -7,3 +7,8 @@ pub mod state;
 pub mod trade;
 
 pub use crate::error::ContractError;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod interface;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::interface::P2PTrading;

--- a/contracts/p2p-trading/src/messages.rs
+++ b/contracts/p2p-trading/src/messages.rs
@@ -6,7 +6,8 @@ use crate::state::{
 use crate::trade::prepare_trade_modification;
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use p2p_trading_export::msg::AddAssetAction;
-use p2p_trading_export::state::{AssetInfo, Comment, TradeState};
+use p2p_trading_export::state::{Comment, TradeState};
+use utils::state::AssetInfo;
 
 pub fn review_counter_trade(
     deps: DepsMut,

--- a/contracts/p2p-trading/src/query.rs
+++ b/contracts/p2p-trading/src/query.rs
@@ -3,6 +3,7 @@ use cosmwasm_std::Api;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{Deps, Order, StdResult, Storage};
 use std::convert::TryInto;
+use utils::state::AssetInfo;
 
 use cw_storage_plus::Bound;
 use schemars::JsonSchema;
@@ -13,7 +14,7 @@ use crate::state::{
     TRADE_INFO,
 };
 use p2p_trading_export::msg::{QueryFilters, TradeInfoResponse};
-use p2p_trading_export::state::{AssetInfo, ContractInfo, CounterTradeInfo, TradeInfo};
+use p2p_trading_export::state::{ContractInfo, CounterTradeInfo, TradeInfo};
 
 use itertools::Itertools;
 // settings for pagination
@@ -155,9 +156,8 @@ pub fn trade_filter(
                 .iter()
                 .any(|asset| match asset {
                     AssetInfo::Coin(x) => x.denom == token.as_ref(),
-                    AssetInfo::Cw20Coin(x) => x.address == token.as_ref(),
                     AssetInfo::Cw721Coin(x) => x.address == token.as_ref(),
-                    AssetInfo::Cw1155Coin(x) => x.address == token.as_ref(),
+                    AssetInfo::Sg721Token(x) => x.address == token.as_ref(),
                 }),
             None => true,
         } && match &filters.assets_withdrawn {

--- a/contracts/raffles/schema/raffles.json
+++ b/contracts/raffles/schema/raffles.json
@@ -961,6 +961,15 @@
                 "type": "null"
               }
             ]
+          },
+          "whitelist": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false
@@ -1568,6 +1577,15 @@
             },
             "raffle_start_timestamp": {
               "$ref": "#/definitions/Timestamp"
+            },
+            "whitelist": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/Addr"
+              }
             }
           },
           "additionalProperties": false
@@ -2518,6 +2536,15 @@
             },
             "raffle_start_timestamp": {
               "$ref": "#/definitions/Timestamp"
+            },
+            "whitelist": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/Addr"
+              }
             }
           },
           "additionalProperties": false

--- a/contracts/raffles/schema/raw/execute.json
+++ b/contracts/raffles/schema/raw/execute.json
@@ -702,6 +702,15 @@
               "type": "null"
             }
           ]
+        },
+        "whitelist": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/contracts/raffles/schema/raw/response_to_all_raffles.json
+++ b/contracts/raffles/schema/raw/response_to_all_raffles.json
@@ -353,6 +353,15 @@
         },
         "raffle_start_timestamp": {
           "$ref": "#/definitions/Timestamp"
+        },
+        "whitelist": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
         }
       },
       "additionalProperties": false

--- a/contracts/raffles/schema/raw/response_to_raffle_info.json
+++ b/contracts/raffles/schema/raw/response_to_raffle_info.json
@@ -366,6 +366,15 @@
         },
         "raffle_start_timestamp": {
           "$ref": "#/definitions/Timestamp"
+        },
+        "whitelist": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
         }
       },
       "additionalProperties": false

--- a/contracts/raffles/src/state.rs
+++ b/contracts/raffles/src/state.rs
@@ -264,6 +264,7 @@ pub struct RaffleOptions {
     pub raffle_preview: u32,               // ?
     pub min_ticket_number: Option<u32>,    // Minimum ticket number for a raffle to close.
     pub one_winner_per_asset: bool, // Allows to set multiple winners per raffle (one per asset)
+    pub whitelist: Option<Vec<Addr>>,
 
     pub gating_raffle: Vec<AdvantageOptions>, // Allows for token gating raffle tickets. Only owners of those tokens can buy raffle tickets
 }
@@ -280,6 +281,9 @@ impl From<RaffleOptions> for RaffleOptionsMsg {
             one_winner_per_asset: value.one_winner_per_asset,
             min_ticket_number: value.min_ticket_number,
             gating_raffle: value.gating_raffle.into_iter().map(Into::into).collect(),
+            whitelist: value
+                .whitelist
+                .map(|v| v.into_iter().map(Into::into).collect()),
         }
     }
 }
@@ -436,6 +440,7 @@ pub struct RaffleOptionsMsg {
     pub raffle_preview: Option<u32>,
     pub one_winner_per_asset: bool,
     pub min_ticket_number: Option<u32>,
+    pub whitelist: Option<Vec<String>>,
 
     pub gating_raffle: Vec<AdvantageOptionsMsg>,
 }
@@ -596,6 +601,14 @@ impl RaffleOptions {
             } else {
                 raffle_options.min_ticket_number
             },
+            whitelist: raffle_options
+                .whitelist
+                .map(|v| {
+                    v.into_iter()
+                        .map(|a| api.addr_validate(&a))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
 
             gating_raffle: raffle_options
                 .gating_raffle
@@ -650,6 +663,14 @@ impl RaffleOptions {
             } else {
                 raffle_options.min_ticket_number
             },
+            whitelist: raffle_options
+                .whitelist
+                .map(|v| {
+                    v.into_iter()
+                        .map(|a| api.addr_validate(&a))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
 
             gating_raffle: raffle_options
                 .gating_raffle

--- a/contracts/raffles/src/utils.rs
+++ b/contracts/raffles/src/utils.rs
@@ -313,6 +313,13 @@ pub fn buyer_can_buy_ticket(
     raffle_info: &RaffleInfo,
     buyer: String,
 ) -> Result<(), ContractError> {
+    // We check that the buyer is whitelisted if any
+    if let Some(whitelist) = &raffle_info.raffle_options.whitelist {
+        if !whitelist.contains(&Addr::unchecked(&buyer)) {
+            return Err(StdError::generic_err("Ticket buyer not whitelisted").into());
+        }
+    }
+
     // We also check if the raffle is token gated
     raffle_info
         .raffle_options

--- a/packages/p2p-trading/Cargo.toml
+++ b/packages/p2p-trading/Cargo.toml
@@ -28,6 +28,8 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 strum = "0.24"
 strum_macros = "0.24"
+cw-orch = "0.23.0"
+utils = { version = "0.1.0", path = "../utils" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/packages/p2p-trading/src/state.rs
+++ b/packages/p2p-trading/src/state.rs
@@ -1,42 +1,11 @@
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Binary, Decimal};
 use strum_macros;
 
-use cosmwasm_std::{Addr, Coin, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Coin, Timestamp};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
 use std::collections::HashSet;
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct Cw1155Coin {
-    pub address: String,
-    pub token_id: String,
-    pub value: Uint128,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct Cw721Coin {
-    pub address: String,
-    pub token_id: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct Cw20Coin {
-    pub address: String,
-    pub amount: Uint128,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum AssetInfo {
-    Cw20Coin(Cw20Coin),
-    Cw721Coin(Cw721Coin),
-    Cw1155Coin(Cw1155Coin),
-    Coin(Coin),
-}
+use utils::state::AssetInfo;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, strum_macros::Display)]
 #[serde(rename_all = "snake_case")]
@@ -54,7 +23,9 @@ pub enum TradeState {
 pub struct ContractInfo {
     pub name: String,
     pub owner: Addr,
-    pub fee_contract: Option<Addr>,
+    pub accept_trade_fee: Vec<Coin>,
+    pub fund_fee: Decimal,
+    pub treasury: Addr,
     pub last_trade_id: Option<u64>,
 }
 

--- a/packages/utils/src/lib.rs
+++ b/packages/utils/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod payment;
 pub mod state;
 pub mod types;

--- a/packages/utils/src/payment.rs
+++ b/packages/utils/src/payment.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::{Coin, MessageInfo, StdError, StdResult};
+
+pub fn assert_payment(msg_info: &MessageInfo, expected_coins: Vec<Coin>) -> StdResult<Coin> {
+    if msg_info.funds.len() != 1 {
+        return Err(StdError::generic_err(format!(
+            "You need to send exactly one coin for payment, received {:?}",
+            msg_info.funds,
+        )));
+    }
+    let sent_coin = &msg_info.funds[0];
+
+    let payment_coin = expected_coins.iter().find(|c| c.denom == sent_coin.denom);
+
+    let Some(payment_coin) = payment_coin else {
+        return Err(StdError::generic_err(format!(
+            "Invalid fee payment sent. Expected {:?}, sent {:?}",
+            expected_coins, msg_info.funds
+        )));
+    };
+
+    if payment_coin.amount > sent_coin.amount {
+        return Err(StdError::generic_err(format!(
+            "Invalid fee payment sent. Expected {}, sent {:?}",
+            payment_coin, msg_info.funds
+        )));
+    }
+
+    Ok(sent_coin.clone())
+}

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -21,9 +21,9 @@ sg721-base.workspace = true
 utils = { version = "0.1.0", path = "../packages/utils" }
 
 # Dao-Dao
-dao-cw-orch = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-dao-pre-propose-base = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-dao-pre-propose-single = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-# dao-cw-orch = { path = "../../../abstract/dao-contracts/packages/cw-orch" }
-# dao-pre-propose-base = { path = "../../../abstract/dao-contracts/packages/dao-pre-propose-base" }
-# dao-pre-propose-single = { path = "../../../abstract/dao-contracts/contracts/pre-propose/dao-pre-propose-single" }
+# dao-cw-orch = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+# dao-pre-propose-base = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+# dao-pre-propose-single = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+dao-cw-orch = { path = "../../../abstract/dao-contracts/packages/cw-orch" }
+dao-pre-propose-base = { path = "../../../abstract/dao-contracts/packages/dao-pre-propose-base" }
+dao-pre-propose-single = { path = "../../../abstract/dao-contracts/contracts/pre-propose/dao-pre-propose-single" }

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -21,6 +21,9 @@ sg721-base.workspace = true
 utils = { version = "0.1.0", path = "../packages/utils" }
 
 # Dao-Dao
-dao-cw-orch = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-dao-pre-propose-base = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-dao-pre-propose-single = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+# dao-cw-orch = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+# dao-pre-propose-base = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+# dao-pre-propose-single = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+dao-cw-orch = { path = "../../../abstract/dao-contracts/packages/cw-orch" }
+dao-pre-propose-base = { path = "../../../abstract/dao-contracts/packages/dao-pre-propose-base" }
+dao-pre-propose-single = { path = "../../../abstract/dao-contracts/contracts/pre-propose/dao-pre-propose-single" }

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -21,9 +21,9 @@ sg721-base.workspace = true
 utils = { version = "0.1.0", path = "../packages/utils" }
 
 # Dao-Dao
-# dao-cw-orch = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-# dao-pre-propose-base = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-# dao-pre-propose-single = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
-dao-cw-orch = { path = "../../../abstract/dao-contracts/packages/cw-orch" }
-dao-pre-propose-base = { path = "../../../abstract/dao-contracts/packages/dao-pre-propose-base" }
-dao-pre-propose-single = { path = "../../../abstract/dao-contracts/contracts/pre-propose/dao-pre-propose-single" }
+dao-cw-orch = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+dao-pre-propose-base = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+dao-pre-propose-single = { git = "https://github.com/Kayanski/dao-contracts", version = "2.4.2", branch = "development" }
+# dao-cw-orch = { path = "../../../abstract/dao-contracts/packages/cw-orch" }
+# dao-pre-propose-base = { path = "../../../abstract/dao-contracts/packages/dao-pre-propose-base" }
+# dao-pre-propose-single = { path = "../../../abstract/dao-contracts/contracts/pre-propose/dao-pre-propose-single" }

--- a/scripts/src/bin/create_raffle.rs
+++ b/scripts/src/bin/create_raffle.rs
@@ -58,6 +58,7 @@ pub fn main() -> anyhow::Result<()> {
             raffle_preview: None,
             min_ticket_number: None,
             one_winner_per_asset: false,
+            whitelist: None,
             gating_raffle: vec![],
         },
         AssetInfo::Coin(coin(123, "ustars")),

--- a/scripts/src/bin/mainnet-migrate-raffle.rs
+++ b/scripts/src/bin/mainnet-migrate-raffle.rs
@@ -17,12 +17,11 @@ pub fn main() -> anyhow::Result<()> {
         .build()?;
 
     let raffles = Raffles::new(chain.clone());
+    raffles.upload()?;
 
-    // raffles.upload()?;
-
-    let proposal_title = "Migrate Raffles to 0.5.2";
+    let proposal_title = "Migrate Raffles to 0.7.3";
     let proposal_description =
-        "This migrates the raffle contract to avoid conflicts when claiming raffles";
+        "This migrates the raffle contract to allow for whitelisting raffles to certain addresses";
     let msg = WasmMsg::Migrate {
         contract_addr: raffles.address()?.to_string(),
         new_code_id: raffles.code_id()?,
@@ -33,11 +32,11 @@ pub fn main() -> anyhow::Result<()> {
     let chain = Daemon::builder().chain(STARGAZE_1).build()?;
 
     let dao_proposal = DaoPreProposeSingle::new("atlas-dao-pre-proposal", chain.clone());
-    /// New version is not compatible
-    // dao_proposal.propose(dao_pre_propose_single::contract::ProposeMessage::Propose {
-    //     title: proposal_title.to_string(),
-    //     description: proposal_description.to_string(),
-    //     msgs: vec![msg.into()],
-    // })?;
+    // New version is not compatible
+    dao_proposal.propose(dao_pre_propose_single::contract::ProposeMessage::Propose {
+        title: proposal_title.to_string(),
+        description: proposal_description.to_string(),
+        msgs: vec![msg.into()],
+    })?;
     Ok(())
 }

--- a/scripts/src/bin/mainnet-migrate-raffle.rs
+++ b/scripts/src/bin/mainnet-migrate-raffle.rs
@@ -33,11 +33,11 @@ pub fn main() -> anyhow::Result<()> {
     let chain = Daemon::builder().chain(STARGAZE_1).build()?;
 
     let dao_proposal = DaoPreProposeSingle::new("atlas-dao-pre-proposal", chain.clone());
-    dao_proposal.propose(dao_pre_propose_single::contract::ProposeMessage::Propose {
-        title: proposal_title.to_string(),
-        description: proposal_description.to_string(),
-        msgs: vec![msg.into()],
-    })?;
-
+    /// New version is not compatible
+    // dao_proposal.propose(dao_pre_propose_single::contract::ProposeMessage::Propose {
+    //     title: proposal_title.to_string(),
+    //     description: proposal_description.to_string(),
+    //     msgs: vec![msg.into()],
+    // })?;
     Ok(())
 }

--- a/scripts/src/bin/mainnet-migrate-raffle.rs
+++ b/scripts/src/bin/mainnet-migrate-raffle.rs
@@ -18,7 +18,7 @@ pub fn main() -> anyhow::Result<()> {
 
     let raffles = Raffles::new(chain.clone());
 
-    raffles.upload()?;
+    // raffles.upload()?;
 
     let proposal_title = "Migrate Raffles to 0.5.2";
     let proposal_description =
@@ -29,13 +29,14 @@ pub fn main() -> anyhow::Result<()> {
         msg: to_json_binary(&MigrateMsg {})?,
     };
 
-    // Then we do the migration proposal
+    // Then we do the migration proposal (no authz_granter this time)
+    let chain = Daemon::builder().chain(STARGAZE_1).build()?;
+
     let dao_proposal = DaoPreProposeSingle::new("atlas-dao-pre-proposal", chain.clone());
     dao_proposal.propose(dao_pre_propose_single::contract::ProposeMessage::Propose {
         title: proposal_title.to_string(),
         description: proposal_description.to_string(),
         msgs: vec![msg.into()],
-        vote: None,
     })?;
 
     Ok(())

--- a/scripts/src/bin/mainnet-migrate-raffle.rs
+++ b/scripts/src/bin/mainnet-migrate-raffle.rs
@@ -32,11 +32,12 @@ pub fn main() -> anyhow::Result<()> {
     let chain = Daemon::builder().chain(STARGAZE_1).build()?;
 
     let dao_proposal = DaoPreProposeSingle::new("atlas-dao-pre-proposal", chain.clone());
-    // New version is not compatible
-    dao_proposal.propose(dao_pre_propose_single::contract::ProposeMessage::Propose {
-        title: proposal_title.to_string(),
-        description: proposal_description.to_string(),
-        msgs: vec![msg.into()],
-    })?;
+    // // New version is not compatible, use the old version of dao-dao and add cw-orch
+    // // This commit for instance : 8c945acdb0746ec84d15cfebeadcfe32122f85a2
+    // dao_proposal.propose(dao_pre_propose_single::contract::ProposeMessage::Propose {
+    //     title: proposal_title.to_string(),
+    //     description: proposal_description.to_string(),
+    //     msgs: vec![msg.into()],
+    // })?;
     Ok(())
 }

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -56,6 +56,11 @@ cw-utils.workspace = true
 dao-voting = "2.3.0"
 dao-pre-propose-single = "2.3.0"
 hex = "0.4.3"
+cw-orch = { version = "0.23.0", features = ["daemon"] }
+p2p-trading = { version = "0.9.0", path = "../contracts/p2p-trading" }
+p2p-trading-export = { version = "0.1.0", path = "../packages/p2p-trading" }
+cw-orch-clone-testing = "0.5.2"
+cw721-base = { git = "https://github.com/AbstractSDK/cw-nfts", version = "0.18.0" }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -4,3 +4,5 @@ pub mod common_setup;
 mod loan;
 #[cfg(test)]
 mod raffle;
+#[cfg(test)]
+mod trading;

--- a/test-suite/src/raffle/setup/execute_msg.rs
+++ b/test-suite/src/raffle/setup/execute_msg.rs
@@ -49,6 +49,7 @@ pub fn create_raffle_function(params: CreateRaffleParams) -> Result<AppResponse,
                 one_winner_per_asset: false,
                 gating_raffle: vec![],
                 min_ticket_number: None,
+                whitelist: None,
             },
             raffle_ticket_price: AssetInfo::Coin(Coin {
                 denom: "ustars".to_string(),
@@ -110,6 +111,7 @@ pub fn create_raffle_setup(params: CreateRaffleParams) -> anyhow::Result<()> {
                 one_winner_per_asset: false,
                 gating_raffle: params.gating,
                 min_ticket_number: params.min_ticket_number,
+                whitelist: None,
             },
             raffle_ticket_price: AssetInfo::Coin(Coin {
                 denom: "ustars".to_string(),

--- a/test-suite/src/raffle/tests/create_and_modify.rs
+++ b/test-suite/src/raffle/tests/create_and_modify.rs
@@ -85,6 +85,7 @@ mod tests {
                         max_ticket_per_address: None,
                         raffle_preview: 0,
                         one_winner_per_asset: false,
+                        whitelist: None,
                         gating_raffle: vec![],
                         min_ticket_number: None,
                     }
@@ -127,6 +128,7 @@ mod tests {
                         max_ticket_per_address: None,
                         raffle_preview: 0,
                         one_winner_per_asset: false,
+                        whitelist: None,
                         gating_raffle: vec![],
                         min_ticket_number: None,
                     }
@@ -260,6 +262,7 @@ mod tests {
                         max_ticket_per_address: None,
                         raffle_preview: None,
                         one_winner_per_asset: false,
+                        whitelist: None,
                         gating_raffle: vec![],
                         min_ticket_number: None,
                     },
@@ -287,6 +290,7 @@ mod tests {
                     max_ticket_per_address: None,
                     raffle_preview: None,
                     one_winner_per_asset: false,
+                    whitelist: None,
                     gating_raffle: vec![],
                     min_ticket_number: None,
                 },
@@ -318,6 +322,7 @@ mod tests {
                         max_ticket_per_address: None,
                         raffle_preview: None,
                         one_winner_per_asset: false,
+                        whitelist: None,
                         gating_raffle: vec![],
                         min_ticket_number: None,
                     },
@@ -355,6 +360,7 @@ mod tests {
                         max_ticket_per_address: None,
                         raffle_preview: 0,
                         one_winner_per_asset: false,
+                        whitelist: None,
                         gating_raffle: vec![],
                         min_ticket_number: None,
                     }
@@ -379,6 +385,7 @@ mod tests {
                         max_ticket_per_address: None,
                         raffle_preview: None,
                         one_winner_per_asset: false,
+                        whitelist: None,
                         gating_raffle: vec![],
                         min_ticket_number: None,
                     },
@@ -416,6 +423,7 @@ mod tests {
                         max_ticket_per_address: None,
                         raffle_preview: 0,
                         one_winner_per_asset: false,
+                        whitelist: None,
                         gating_raffle: vec![],
                         min_ticket_number: None,
                     }

--- a/test-suite/src/raffle/tests/multiple_winners.rs
+++ b/test-suite/src/raffle/tests/multiple_winners.rs
@@ -53,6 +53,7 @@ mod tests {
                         raffle_preview: None,
                         one_winner_per_asset: true,
                         min_ticket_number: None,
+                        whitelist: None,
                         gating_raffle: vec![],
                     },
                     raffle_ticket_price: AssetInfo::Coin(Coin {
@@ -169,6 +170,7 @@ mod tests {
                         raffle_preview: None,
                         one_winner_per_asset: true,
                         min_ticket_number: None,
+                        whitelist: None,
                         gating_raffle: vec![],
                     },
                     raffle_ticket_price: AssetInfo::Coin(Coin {
@@ -291,6 +293,7 @@ mod tests {
                         raffle_preview: None,
                         one_winner_per_asset: true,
                         min_ticket_number: None,
+                        whitelist: None,
                         gating_raffle: vec![],
                     },
                     raffle_ticket_price: AssetInfo::Coin(Coin {

--- a/test-suite/src/raffle/tests/ticket_limits.rs
+++ b/test-suite/src/raffle/tests/ticket_limits.rs
@@ -77,6 +77,7 @@ mod tests {
                         min_ticket_number: None,
                         one_winner_per_asset: false,
                         gating_raffle: vec![],
+                        whitelist: None,
                     },
                     raffle_ticket_price: AssetInfo::Coin(Coin {
                         denom: "ustars".to_string(),
@@ -253,6 +254,7 @@ mod tests {
                         raffle_preview: None,
                         one_winner_per_asset: false,
                         gating_raffle: vec![],
+                        whitelist: None,
                         min_ticket_number: None,
                     },
                     raffle_ticket_price: AssetInfo::Coin(Coin {
@@ -301,6 +303,7 @@ mod tests {
                     raffle_preview: 0,
                     one_winner_per_asset: false,
                     gating_raffle: vec![],
+                    whitelist: None,
                     min_ticket_number: None,
                 }
             }

--- a/test-suite/src/trading/clone_testing.rs
+++ b/test-suite/src/trading/clone_testing.rs
@@ -1,0 +1,331 @@
+use cosmwasm_std::{coin, coins, Coins, Decimal, Uint128};
+use cw721_base::interface::{Cw721, ExecuteMsg};
+use cw_orch::{prelude::*, tokio::runtime::Runtime};
+use cw_orch_clone_testing::CloneTesting;
+use p2p_trading::P2PTrading;
+use p2p_trading_export::msg::{AddAssetAction, ExecuteMsgFns, InstantiateMsg};
+use utils::state::{AssetInfo, Sg721Token};
+
+use super::STARGAZE_1;
+
+pub const SNS_ADDRESS: &str = "stars1fx74nkqkw2748av8j7ew7r3xt9cgjqduwn8m0ur5lhe49uhlsasszc5fhr";
+pub const GECKIES_ADDRESS: &str =
+    "stars166kqwcu8789xh7nk07fcrdzek54205u8gzas684lnas2kzalksqsg5xhqf";
+pub const GECKIES_ID: &str = "790";
+
+pub const SNS: &str = "jacobremy";
+pub const OWNER: &str = "stars1f4fqgj2htmpff6qe5nnhgl42pevekl34ykdah9";
+
+pub const COUNTER_TRADER: &str = "stars14kr4pdxuy8xfgutz3xvmlwdlmuhh6jwq42p20p";
+pub const COUNTER_ID: &str = "2887";
+
+pub const NICOCO_FEE_AMOUNT: u128 = 498579754654;
+pub const FEE_AMOUNT: u128 = 4514987;
+pub const FEE_DENOM: &str = "ustars";
+
+pub const FUND_FEE: Decimal = Decimal::percent(3);
+
+pub const FIRST_FUND_AMOUNT: u128 = 485;
+pub const SECOND_FUND_AMOUNT: u128 = 456;
+
+#[test]
+fn actual_nft() -> anyhow::Result<()> {
+    let rt = Runtime::new()?;
+    let mut chain = CloneTesting::new(&rt, STARGAZE_1)?;
+    chain.set_sender(Addr::unchecked(OWNER));
+
+    let treasury = chain.app.borrow().api().addr_make("treasury");
+
+    let nft: Cw721<CloneTesting> = Cw721::new("geckies", chain.clone());
+    nft.set_address(&Addr::unchecked(GECKIES_ADDRESS));
+
+    let p2p = P2PTrading::new(chain.clone());
+    p2p.upload()?;
+    p2p.instantiate(
+        &InstantiateMsg {
+            name: "AtlasDaoTrading".to_string(),
+            owner: None,
+            accept_trade_fee: vec![
+                coin(NICOCO_FEE_AMOUNT, "nicoco"),
+                coin(FEE_AMOUNT, FEE_DENOM),
+            ],
+            fund_fee: FUND_FEE,
+            treasury: treasury.to_string(),
+        },
+        None,
+        None,
+    )?;
+
+    nft.execute(
+        &ExecuteMsg::ApproveAll {
+            operator: p2p.address()?.to_string(),
+            expires: None,
+        },
+        None,
+    )?;
+    nft.call_as(&Addr::unchecked(COUNTER_TRADER)).execute(
+        &ExecuteMsg::ApproveAll {
+            operator: p2p.address()?.to_string(),
+            expires: None,
+        },
+        None,
+    )?;
+
+    p2p.create_trade(None, None)?;
+    p2p.add_asset(
+        AddAssetAction::ToLastTrade {},
+        AssetInfo::Sg721Token(Sg721Token {
+            address: nft.address()?.to_string(),
+            token_id: GECKIES_ID.to_string(),
+        }),
+        &[],
+    )?;
+
+    p2p.confirm_trade(None)?;
+    let trade_id = 0;
+
+    let counter_p2p = p2p.call_as(&Addr::unchecked(COUNTER_TRADER));
+
+    counter_p2p.suggest_counter_trade(trade_id, None)?;
+    counter_p2p.add_asset(
+        AddAssetAction::ToLastCounterTrade { trade_id },
+        AssetInfo::Sg721Token(Sg721Token {
+            address: nft.address()?.to_string(),
+            token_id: COUNTER_ID.to_string(),
+        }),
+        &[],
+    )?;
+
+    counter_p2p.confirm_counter_trade(trade_id, None)?;
+
+    let counter_id = 0;
+    p2p.accept_trade(counter_id, trade_id, None)?;
+    p2p.withdraw_successful_trade(trade_id, &coins(FEE_AMOUNT, FEE_DENOM))?;
+    counter_p2p.withdraw_successful_trade(trade_id, &coins(FEE_AMOUNT, FEE_DENOM))?;
+
+    let treasury_balance = chain.balance(treasury, Some(FEE_DENOM.to_string()))?;
+    assert_eq!(treasury_balance, coins(2 * FEE_AMOUNT, FEE_DENOM));
+    Ok(())
+}
+
+#[test]
+fn sns() -> anyhow::Result<()> {
+    let rt = Runtime::new()?;
+    let mut chain = CloneTesting::new(&rt, STARGAZE_1)?;
+    chain.set_sender(Addr::unchecked(OWNER));
+
+    let nft: Cw721<CloneTesting> = Cw721::new("geckies", chain.clone());
+    nft.set_address(&Addr::unchecked(GECKIES_ADDRESS));
+    let sns = Cw721::new("sns", chain.clone());
+    sns.set_address(&Addr::unchecked(SNS_ADDRESS));
+
+    let p2p = P2PTrading::new(chain.clone());
+    p2p.upload()?;
+
+    let treasury = chain.app.borrow().api().addr_make("treasury");
+    p2p.instantiate(
+        &InstantiateMsg {
+            name: "AtlasDaoTrading".to_string(),
+            owner: None,
+            accept_trade_fee: vec![
+                coin(NICOCO_FEE_AMOUNT, "nicoco"),
+                coin(FEE_AMOUNT, FEE_DENOM),
+            ],
+            fund_fee: FUND_FEE,
+            treasury: treasury.to_string(),
+        },
+        None,
+        None,
+    )?;
+
+    sns.execute(
+        &ExecuteMsg::ApproveAll {
+            operator: p2p.address()?.to_string(),
+            expires: None,
+        },
+        None,
+    )?;
+    nft.call_as(&Addr::unchecked(COUNTER_TRADER)).execute(
+        &ExecuteMsg::ApproveAll {
+            operator: p2p.address()?.to_string(),
+            expires: None,
+        },
+        None,
+    )?;
+
+    p2p.create_trade(None, None)?;
+    p2p.add_asset(
+        AddAssetAction::ToLastTrade {},
+        AssetInfo::Sg721Token(Sg721Token {
+            address: sns.address()?.to_string(),
+            token_id: SNS.to_string(),
+        }),
+        &[],
+    )?;
+
+    p2p.confirm_trade(None)?;
+    let trade_id = 0;
+
+    let counter_p2p = p2p.call_as(&Addr::unchecked(COUNTER_TRADER));
+
+    counter_p2p.suggest_counter_trade(trade_id, None)?;
+    counter_p2p.add_asset(
+        AddAssetAction::ToLastCounterTrade { trade_id },
+        AssetInfo::Sg721Token(Sg721Token {
+            address: nft.address()?.to_string(),
+            token_id: COUNTER_ID.to_string(),
+        }),
+        &[],
+    )?;
+
+    counter_p2p.confirm_counter_trade(trade_id, None)?;
+
+    let counter_id = 0;
+    p2p.accept_trade(counter_id, trade_id, None)?;
+    p2p.withdraw_successful_trade(trade_id, &coins(FEE_AMOUNT, FEE_DENOM))?;
+    counter_p2p.withdraw_successful_trade(trade_id, &coins(FEE_AMOUNT, FEE_DENOM))?;
+
+    let treasury_balance = chain.balance(treasury, Some(FEE_DENOM.to_string()))?;
+    assert_eq!(treasury_balance, coins(2 * FEE_AMOUNT, FEE_DENOM));
+
+    Ok(())
+}
+
+#[test]
+fn with_funds() -> anyhow::Result<()> {
+    let rt = Runtime::new()?;
+    let mut chain = CloneTesting::new(&rt, STARGAZE_1)?;
+    chain.set_sender(Addr::unchecked(OWNER));
+
+    let treasury = chain.app.borrow().api().addr_make("treasury");
+
+    let nft: Cw721<CloneTesting> = Cw721::new("geckies", chain.clone());
+    nft.set_address(&Addr::unchecked(GECKIES_ADDRESS));
+    let sns = Cw721::new("sns", chain.clone());
+    sns.set_address(&Addr::unchecked(SNS_ADDRESS));
+
+    let p2p = P2PTrading::new(chain.clone());
+    p2p.upload()?;
+    p2p.instantiate(
+        &InstantiateMsg {
+            name: "AtlasDaoTrading".to_string(),
+            owner: None,
+            accept_trade_fee: vec![
+                coin(NICOCO_FEE_AMOUNT, "nicoco"),
+                coin(FEE_AMOUNT, FEE_DENOM),
+            ],
+            fund_fee: FUND_FEE,
+            treasury: treasury.to_string(),
+        },
+        None,
+        None,
+    )?;
+
+    sns.execute(
+        &ExecuteMsg::ApproveAll {
+            operator: p2p.address()?.to_string(),
+            expires: None,
+        },
+        None,
+    )?;
+    nft.call_as(&Addr::unchecked(COUNTER_TRADER)).execute(
+        &ExecuteMsg::ApproveAll {
+            operator: p2p.address()?.to_string(),
+            expires: None,
+        },
+        None,
+    )?;
+
+    p2p.create_trade(None, None)?;
+    p2p.add_asset(
+        AddAssetAction::ToLastTrade {},
+        AssetInfo::Sg721Token(Sg721Token {
+            address: sns.address()?.to_string(),
+            token_id: SNS.to_string(),
+        }),
+        &[],
+    )?;
+
+    p2p.get_chain().add_balance(
+        &p2p.get_chain().sender(),
+        vec![
+            coin(FIRST_FUND_AMOUNT, "uarch"),
+            coin(SECOND_FUND_AMOUNT, "uatlas"),
+        ],
+    )?;
+    p2p.add_asset(
+        AddAssetAction::ToLastTrade {},
+        AssetInfo::Coin(coin(FIRST_FUND_AMOUNT, "uarch")),
+        &coins(FIRST_FUND_AMOUNT, "uarch"),
+    )?;
+    p2p.add_asset(
+        AddAssetAction::ToLastTrade {},
+        AssetInfo::Coin(coin(SECOND_FUND_AMOUNT, "uatlas")),
+        &coins(SECOND_FUND_AMOUNT, "uatlas"),
+    )?;
+
+    p2p.confirm_trade(None)?;
+    let trade_id = 0;
+
+    let counter_p2p = p2p.call_as(&Addr::unchecked(COUNTER_TRADER));
+
+    counter_p2p.suggest_counter_trade(trade_id, None)?;
+    counter_p2p.add_asset(
+        AddAssetAction::ToLastCounterTrade { trade_id },
+        AssetInfo::Sg721Token(Sg721Token {
+            address: nft.address()?.to_string(),
+            token_id: COUNTER_ID.to_string(),
+        }),
+        &[],
+    )?;
+    counter_p2p.get_chain().add_balance(
+        &counter_p2p.get_chain().sender(),
+        vec![
+            coin(FIRST_FUND_AMOUNT, "ujuno"),
+            coin(SECOND_FUND_AMOUNT, "uosmosis"),
+        ],
+    )?;
+    counter_p2p.add_asset(
+        AddAssetAction::ToLastCounterTrade { trade_id },
+        AssetInfo::Coin(coin(FIRST_FUND_AMOUNT, "ujuno")),
+        &coins(FIRST_FUND_AMOUNT, "ujuno"),
+    )?;
+    counter_p2p.add_asset(
+        AddAssetAction::ToLastCounterTrade { trade_id },
+        AssetInfo::Coin(coin(SECOND_FUND_AMOUNT, "uosmosis")),
+        &coins(SECOND_FUND_AMOUNT, "uosmosis"),
+    )?;
+
+    counter_p2p.confirm_counter_trade(trade_id, None)?;
+
+    let counter_id = 0;
+    p2p.accept_trade(counter_id, trade_id, None)?;
+    let response1 = p2p.withdraw_successful_trade(trade_id, &coins(FEE_AMOUNT, FEE_DENOM))?;
+    let response2 =
+        counter_p2p.withdraw_successful_trade(trade_id, &coins(FEE_AMOUNT, FEE_DENOM))?;
+
+    let treasury_balance = chain.balance(treasury, None)?;
+
+    let mut expected_coins = Coins::default();
+    expected_coins.add(coin(2 * FEE_AMOUNT, FEE_DENOM))?;
+    expected_coins.add(coin(
+        (FUND_FEE * Uint128::from(FIRST_FUND_AMOUNT)).u128(),
+        "uarch",
+    ))?;
+    expected_coins.add(coin(
+        (FUND_FEE * Uint128::from(FIRST_FUND_AMOUNT)).u128(),
+        "ujuno",
+    ))?;
+    expected_coins.add(coin(
+        (FUND_FEE * Uint128::from(SECOND_FUND_AMOUNT)).u128(),
+        "uatlas",
+    ))?;
+    expected_coins.add(coin(
+        (FUND_FEE * Uint128::from(SECOND_FUND_AMOUNT)).u128(),
+        "uosmosis",
+    ))?;
+
+    assert_eq!(treasury_balance, expected_coins.to_vec());
+
+    Ok(())
+}

--- a/test-suite/src/trading/mod.rs
+++ b/test-suite/src/trading/mod.rs
@@ -1,0 +1,32 @@
+mod clone_testing;
+use cw_orch::environment::{ChainInfo, ChainKind, NetworkInfo};
+
+pub const STARGAZE_NETWORK: NetworkInfo = NetworkInfo {
+    chain_name: "stargaze",
+    pub_address_prefix: "stars",
+    coin_type: 118u32,
+};
+
+/// https://github.com/cosmos/chain-registry/blob/master/testnets/stargazetestnet/chain.json
+pub const ELGAFAR_1: ChainInfo = ChainInfo {
+    kind: ChainKind::Testnet,
+    chain_id: "elgafar-1",
+    gas_denom: "ustars",
+    gas_price: 0.04,
+    grpc_urls: &["http://grpc-1.elgafar-1.stargaze-apis.com:26660"],
+    network_info: STARGAZE_NETWORK,
+    lcd_url: None,
+    fcd_url: None,
+};
+
+/// https://github.com/cosmos/chain-registry/blob/master/testnets/stargazetestnet/chain.json
+pub const STARGAZE_1: ChainInfo = ChainInfo {
+    kind: ChainKind::Mainnet,
+    chain_id: "stargaze-1",
+    gas_denom: "ustars",
+    gas_price: 1.1,
+    grpc_urls: &["http://stargaze-grpc.polkachu.com:13790"],
+    network_info: STARGAZE_NETWORK,
+    lcd_url: None,
+    fcd_url: None,
+};


### PR DESCRIPTION
This PR aims at solving 4.6
4.6  New Type of raffle (URGENT)
Ability to create a raffle where only selected addresses can participate, set by the creator. 
Be able to determine how many tickets per wallet. So creator can limit how many ticket a wallet can get
Ability to airdrop raffle ticket

